### PR TITLE
[FEAT] Todo 관련 엔티티 구현

### DIFF
--- a/backend/src/main/java/com/dubu/backend/todo/entity/Category.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Category.java
@@ -1,0 +1,26 @@
+package com.dubu.backend.todo.entity;
+
+import com.dubu.backend.global.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(length = 20, nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Todo> todos = new ArrayList<>();
+}

--- a/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
@@ -1,0 +1,59 @@
+package com.dubu.backend.todo.entity;
+
+import com.dubu.backend.global.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Todo extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "todo_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TodoType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "difficulty", nullable = false)
+    private TodoDifficulty todoDifficulty;
+
+    @Column(length = 500)
+    private String memo ;
+
+    @Column(name = "scheduled_date", columnDefinition = "DATE")
+    private LocalDate scheduledDate;
+
+    @Column(name = "spent_time", columnDefinition = "MEDIUMINT")
+    private Integer spentTime;
+
+    @Column(name = "is_done", columnDefinition = "TINYINT(1)")
+    private Boolean isDone;
+
+    @Column(name = "is_deleted", columnDefinition = "TINYINT(1)")
+    private Boolean isDeleted;
+
+    // Member 엔티티 구현되면 포함
+    // @ManyToOne(fetch =  FetchType.LAZY)
+    // @JoinColumn(name = "member_id")
+    // private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    // Route 엔티티 구현되면 포함
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "route_id")
+    // private Route route;
+}

--- a/backend/src/main/java/com/dubu/backend/todo/entity/TodoDifficulty.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/TodoDifficulty.java
@@ -1,0 +1,11 @@
+package com.dubu.backend.todo.entity;
+
+public enum TodoDifficulty {
+    EASY("쉬움"), NORMAL("보통"), HARD("어려움");
+
+    private String name;
+
+    TodoDifficulty(String name) {
+        this.name = name;
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/todo/entity/TodoType.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/TodoType.java
@@ -1,0 +1,5 @@
+package com.dubu.backend.todo.entity;
+
+public enum TodoType {
+    SAVE, RECOMMEND, OTHER
+}


### PR DESCRIPTION
## Issue Number
close #10 
## As-Is
<!-- 문제 상황 정의 -->
- Todo, Category 엔티티 클래스 생성  
## To-Be
<!-- 변경 사항 -->
- [x] Todo, Category 엔티티 클래스 생성
- [x] Todo 엔티티를 위한 TodoType, TodoDifficulty enum 타입 생성
## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
![image](https://github.com/user-attachments/assets/329ea1e4-84bf-4e2f-afda-7ecaee8b6b08)
![image](https://github.com/user-attachments/assets/56b90267-8164-47f9-9f63-39529f2b187f)


## (Optional) Additional Description
Boolean 타입의 값을 Mysql 의 bit 타입으로 설정하는 것이 아닌 TINIYINT 로 설정

이유:
- bit 타입도 Mysql 안에서는 1바이트 공간을 차지해서 공간 상의 이익이 없다.
- bit 타입은 오히려 특정 함수 사용시 타입 변환으로 쿼리 처리 시간이 더 길 수 있다.

[참고자료](https://www.bennadel.com/blog/3845-why-i-use-tinyint-columns-instead-of-bit-columns-for-boolean-data-in-a-mysql-application.htm)


Todo 엔티티의 type, difficulty 값을 Enum 으로 관리한다. DB에서는 ENUM 타입으로 저장

이유: 
- Mysql 에서만 사용하는 타입이라 DB 종속적일 수 있으나 공간을 절약할 수 있다.
