### PR TITLE
[FEAT] 공통 헤더 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Header/Header.constants.ts
+++ b/frontend/src/components/Header/Header.constants.ts
@@ -1,0 +1,13 @@
+import { IconType } from '../Icon';
+
+export const BUTTONS: Record<string, { text: string; icon?: IconType }> = {
+  BACK: { text: '뒤로 가기', icon: 'Chevron' },
+  HOME: { text: '처음으로 가기', icon: 'Home' },
+  MENU: { text: '메뉴 열기', icon: 'Menu' },
+  NEXT: { text: '다음' },
+  COMPLETE: { text: '완료' },
+};
+
+export const PATHS = {
+  HOME: '/',
+};

--- a/frontend/src/components/Header/Header.styled.ts
+++ b/frontend/src/components/Header/Header.styled.ts
@@ -35,7 +35,7 @@ export const Button = styled.button`
 export const HomeButton = styled(Button)`
   margin-left: 1.4rem;
   border: 0.1rem solid ${({ theme }) => theme.colors.gray200};
-  width: 11.3rem;
+  width: 11.4rem;
   height: 3.4rem;
   ${({ theme }) => theme.fonts.label13Med};
   font-weight: 400;

--- a/frontend/src/components/Header/Header.styled.ts
+++ b/frontend/src/components/Header/Header.styled.ts
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+
+export const HeaderLayout = styled.header`
+  display: grid;
+  grid-template-columns: auto 1fr 5.2rem;
+  align-items: center;
+  height: 5.2rem;
+  padding: 0 1rem 0 0.2rem;
+`;
+
+export const HeaderTitle = styled.h1`
+  color: ${({ theme }) => theme.colors.gray950};
+  ${({ theme }) => theme.fonts.headline17Med};
+  text-align: center;
+`;
+
+export const Button = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.8rem;
+  width: 5.2rem;
+  height: 5.2rem;
+  border: none;
+  border-radius: 0.8rem;
+  color: ${({ theme }) => theme.colors.gray950};
+  ${({ theme }) => theme.fonts.headline17Med};
+
+  &:disabled {
+    color: ${({ theme }) => theme.colors.gray400};
+    pointer-events: none;
+  }
+`;
+
+export const HomeButton = styled(Button)`
+  margin-left: 1.4rem;
+  border: 0.1rem solid ${({ theme }) => theme.colors.gray200};
+  width: 11.3rem;
+  height: 3.4rem;
+  ${({ theme }) => theme.fonts.label13Med};
+  font-weight: 400;
+`;
+
+export const MenuButton = styled(Button)`
+  grid-column: 3;
+`;

--- a/frontend/src/components/Header/HeaderButtons/Back.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Back.tsx
@@ -1,0 +1,14 @@
+import { BUTTONS } from '@/components/Header/Header.constants';
+import * as S from '@/components/Header/Header.styled';
+import { useNavigation } from '@/components/Header/hooks/useNavigation';
+import Icon, { IconType } from '@/components/Icon';
+
+export const Back = () => {
+  const { goToBack } = useNavigation();
+
+  return (
+    <S.Button aria-label={BUTTONS.BACK.text} onClick={goToBack}>
+      <Icon icon={BUTTONS.BACK.icon as IconType} />
+    </S.Button>
+  );
+};

--- a/frontend/src/components/Header/HeaderButtons/Complete.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Complete.tsx
@@ -8,7 +8,7 @@ interface CompleteProps {
 
 export const Complete = ({ disabled = false, onClick }: CompleteProps) => {
   return (
-    <S.Button disabled={disabled} onClick={onClick} aria-label={BUTTONS.COMPLETE.text}>
+    <S.Button disabled={disabled} onClick={onClick}>
       {BUTTONS.COMPLETE.text}
     </S.Button>
   );

--- a/frontend/src/components/Header/HeaderButtons/Complete.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Complete.tsx
@@ -1,0 +1,15 @@
+import { BUTTONS } from '@/components/Header/Header.constants';
+import * as S from '@/components/Header/Header.styled';
+
+interface CompleteProps {
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+export const Complete = ({ disabled = false, onClick }: CompleteProps) => {
+  return (
+    <S.Button disabled={disabled} onClick={onClick} aria-label={BUTTONS.COMPLETE.text}>
+      {BUTTONS.COMPLETE.text}
+    </S.Button>
+  );
+};

--- a/frontend/src/components/Header/HeaderButtons/Home.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Home.tsx
@@ -1,0 +1,15 @@
+import { BUTTONS } from '@/components/Header/Header.constants';
+import * as S from '@/components/Header/Header.styled';
+import { useNavigation } from '@/components/Header/hooks/useNavigation';
+import Icon, { IconType } from '@/components/Icon';
+
+export const Home = () => {
+  const { goToHome } = useNavigation();
+
+  return (
+    <S.HomeButton onClick={goToHome} aria-label={BUTTONS.HOME.text}>
+      <Icon icon={BUTTONS.HOME.icon as IconType} />
+      <span>{BUTTONS.HOME.text}</span>
+    </S.HomeButton>
+  );
+};

--- a/frontend/src/components/Header/HeaderButtons/Menu.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Menu.tsx
@@ -1,0 +1,12 @@
+import { BUTTONS } from '../Header.constants';
+
+import * as S from '@/components/Header/Header.styled';
+import Icon, { IconType } from '@/components/Icon';
+
+export const Menu = () => {
+  return (
+    <S.MenuButton aria-label={BUTTONS.MENU.text}>
+      <Icon icon={BUTTONS.MENU.icon as IconType} />
+    </S.MenuButton>
+  );
+};

--- a/frontend/src/components/Header/HeaderButtons/Next.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Next.tsx
@@ -8,7 +8,7 @@ interface NextProps {
 
 export const Next = ({ disabled = false, onClick }: NextProps) => {
   return (
-    <S.Button disabled={disabled} aria-label={BUTTONS.NEXT.text} onClick={onClick}>
+    <S.Button disabled={disabled} onClick={onClick}>
       {BUTTONS.NEXT.text}
     </S.Button>
   );

--- a/frontend/src/components/Header/HeaderButtons/Next.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Next.tsx
@@ -1,0 +1,15 @@
+import { BUTTONS } from '@/components/Header/Header.constants';
+import * as S from '@/components/Header/Header.styled';
+
+interface NextProps {
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+export const Next = ({ disabled = false, onClick }: NextProps) => {
+  return (
+    <S.Button disabled={disabled} aria-label={BUTTONS.NEXT.text} onClick={onClick}>
+      {BUTTONS.NEXT.text}
+    </S.Button>
+  );
+};

--- a/frontend/src/components/Header/HeaderButtons/index.tsx
+++ b/frontend/src/components/Header/HeaderButtons/index.tsx
@@ -1,0 +1,5 @@
+export { Back } from './Back';
+export { Complete } from './Complete';
+export { Home } from './Home';
+export { Menu } from './Menu';
+export { Next } from './Next';

--- a/frontend/src/components/Header/hooks/useNavigation.ts
+++ b/frontend/src/components/Header/hooks/useNavigation.ts
@@ -1,0 +1,12 @@
+import { useNavigate } from 'react-router';
+
+import { PATHS } from '@/components/Header/Header.constants';
+
+export const useNavigation = () => {
+  const navigate = useNavigate();
+
+  return {
+    goToBack: () => navigate(-1),
+    goToHome: () => navigate(PATHS.HOME),
+  };
+};

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import * as S from './Header.styled';
+import * as Buttons from './HeaderButtons';
+
+interface HeaderProps {
+  children: ReactNode;
+}
+
+const Header = ({ children }: HeaderProps) => {
+  return <S.HeaderLayout>{children}</S.HeaderLayout>;
+};
+
+Header.Title = ({ children }: { children: ReactNode }) => <S.HeaderTitle>{children}</S.HeaderTitle>;
+Header.BackButton = Buttons.Back;
+Header.HomeButton = Buttons.Home;
+Header.NextButton = Buttons.Next;
+Header.CompleteButton = Buttons.Complete;
+Header.MenuButton = Buttons.Menu;
+
+export default Header;


### PR DESCRIPTION
## Issue Number
close #13
## As-Is
<!-- 문제 상황 정의 -->
- 헤더 컴포넌트가 없었어요.

## To-Be
<!-- 변경 사항 -->
- [x] 헤더 컴포넌트 구현

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
<img width="369" alt="image" src="https://github.com/user-attachments/assets/8fb08a94-e056-4e91-8f04-4a64c72f86c8" />


## (Optional) Additional Description

헤더 컴포넌트를 합성 컴포넌트로 구현했습니다.
- 서브 컴포넌트는 다음과 같습니다.
```jsx
  // 헤더 제목
Header.Title = ({ children }: { children: ReactNode }) => <S.HeaderTitle>{children}</S.HeaderTitle>;
Header.BackButton = Buttons.Back;  // 이전페이지로 이동
Header.HomeButton = Buttons.Home; // 메인페이지로 이동 
Header.NextButton = Buttons.Next;  // 다음버튼 (disabled, onClick 을 props로 받습니다)
Header.CompleteButton = Buttons.Complete;  // 완료버튼 (disabled, onClick 을 props로 받습니다)
Header.MenuButton = Buttons.Menu;  // 메뉴버튼
```

- 사용법은 다음과 같습니다.
```jsx
<Header>
  <Header.HomeButton />
  <Header.MenuButton />
</Header>

<Header>
  <Header.MenuButton />
</Header>

<Header>
  <Header.BackButton />
  <Header.Title>회원가입</Header.Title>
  <Header.NextButton />
</Header>

<Header>
  <Header.BackButton />
  <Header.Title>회원가입</Header.Title>
  <Header.CompleteButton disabled={true} />
</Header>

<Header>
  <Header.BackButton />
  <Header.Title>주소 검색하기</Header.Title>
</Header>
```