### PR TITLE
[FEAT] Drawer 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Drawer/Drawer.constants.ts
+++ b/frontend/src/components/Drawer/Drawer.constants.ts
@@ -1,0 +1,6 @@
+// TODO: 경로 수정
+export const DRAWER_MENU = [
+  { text: '주변 둘러보기', path: '/' },
+  { text: '주간 통계', path: '/' },
+  { text: '마이 페이지', path: '/' },
+] as const;

--- a/frontend/src/components/Drawer/Drawer.styled.ts
+++ b/frontend/src/components/Drawer/Drawer.styled.ts
@@ -9,16 +9,20 @@ export const DrawerLayout = styled.div<{ $isOpen: boolean }>`
   width: 37.5rem;
   overflow: hidden;
 
-  z-index: ${({ $isOpen }) => ($isOpen ? 5 : -1)};
+  z-index: 5;
   visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
   opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+
+  transition:
+    visibility 0.3s ease-in-out,
+    opacity 0.3s ease-in-out;
 `;
 
 export const Overlay = styled.div<{ $isOpen: boolean }>`
   position: absolute;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.3);
+  background-color: rgba(0, 0, 0, 0.3);
 `;
 
 export const Content = styled.div<{ $isOpen: boolean }>`
@@ -30,8 +34,8 @@ export const Content = styled.div<{ $isOpen: boolean }>`
   height: 100%;
   padding: 2rem 2.8rem;
 
-  background: ${({ theme }) => theme.colors.white};
-  border-radius: 0 0 0 1.2rem;
+  background-color: ${({ theme }) => theme.colors.white};
+  border-radius: 0 0 0 3.2rem;
 
   display: flex;
   flex-direction: column;
@@ -64,7 +68,7 @@ export const MenuItem = styled.li`
     display: block;
     width: 100%;
     height: 0.15rem;
-    background: ${({ theme }) => theme.colors.gray100};
+    background-color: ${({ theme }) => theme.colors.gray100};
 
     position: absolute;
     bottom: 0;

--- a/frontend/src/components/Drawer/Drawer.styled.ts
+++ b/frontend/src/components/Drawer/Drawer.styled.ts
@@ -42,7 +42,7 @@ export const Content = styled.div<{ $isOpen: boolean }>`
   will-change: transform;
 `;
 
-export const ButtonWrapper = styled.div`
+export const MenuList = styled.ul`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -50,7 +50,7 @@ export const ButtonWrapper = styled.div`
   gap: 1rem;
 `;
 
-export const Button = styled.button`
+export const MenuItem = styled.li`
   width: 100%;
   text-align: left;
   ${({ theme }) => theme.fonts.body16};
@@ -69,5 +69,9 @@ export const Button = styled.button`
     position: absolute;
     bottom: 0;
     left: 0;
+  }
+
+  a {
+    display: block;
   }
 `;

--- a/frontend/src/components/Drawer/Drawer.styled.ts
+++ b/frontend/src/components/Drawer/Drawer.styled.ts
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+
+export const DrawerLayout = styled.div<{ $isOpen: boolean }>`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 50%;
+  transform: translateX(50%);
+  width: 37.5rem;
+  overflow: hidden;
+
+  z-index: ${({ $isOpen }) => ($isOpen ? 5 : -1)};
+  visibility: ${({ $isOpen }) => ($isOpen ? 'visible' : 'hidden')};
+  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+`;
+
+export const Overlay = styled.div<{ $isOpen: boolean }>`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.3);
+`;
+
+export const Content = styled.div<{ $isOpen: boolean }>`
+  position: absolute;
+  top: 0;
+  right: 0;
+
+  width: 22.5rem;
+  height: 100%;
+  padding: 2rem 2.8rem;
+
+  background: ${({ theme }) => theme.colors.white};
+  border-radius: 0 0 0 1.2rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 3.2rem;
+
+  transform: translateX(${({ $isOpen }) => ($isOpen ? '0' : '100%')});
+  transition: transform 0.3s ease-in-out;
+  will-change: transform;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  gap: 1rem;
+`;
+
+export const Button = styled.button`
+  width: 100%;
+  text-align: left;
+  ${({ theme }) => theme.fonts.body16};
+  font-weight: 500;
+
+  position: relative;
+  padding-bottom: 1rem;
+
+  &:not(:last-child)::after {
+    content: '';
+    display: block;
+    width: 100%;
+    height: 0.15rem;
+    background: ${({ theme }) => theme.colors.gray100};
+
+    position: absolute;
+    bottom: 0;
+    left: 0;
+  }
+`;

--- a/frontend/src/components/Drawer/contexts/DrawerContext.tsx
+++ b/frontend/src/components/Drawer/contexts/DrawerContext.tsx
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+interface DrawerContextType {
+  isOpen: boolean;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+}
+
+export const DrawerContext = createContext<DrawerContextType | null>(null);

--- a/frontend/src/components/Drawer/contexts/DrawerProvider.tsx
+++ b/frontend/src/components/Drawer/contexts/DrawerProvider.tsx
@@ -1,0 +1,18 @@
+import { ReactNode, useState } from 'react';
+
+import { DrawerContext } from './DrawerContext';
+
+export const DrawerProvider = ({ children }: { children: ReactNode }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openDrawer = () => setIsOpen(true);
+  const closeDrawer = () => setIsOpen(false);
+
+  const value = {
+    isOpen,
+    openDrawer,
+    closeDrawer,
+  };
+
+  return <DrawerContext.Provider value={value}>{children}</DrawerContext.Provider>;
+};

--- a/frontend/src/components/Drawer/hooks/useDrawer.ts
+++ b/frontend/src/components/Drawer/hooks/useDrawer.ts
@@ -1,0 +1,12 @@
+import { useContext } from 'react';
+
+import { DrawerContext } from '../contexts/DrawerContext';
+
+export const useDrawer = () => {
+  const context = useContext(DrawerContext);
+  if (!context) {
+    throw new Error('useDrawer must be used within DrawerProvider');
+  }
+
+  return context;
+};

--- a/frontend/src/components/Drawer/index.tsx
+++ b/frontend/src/components/Drawer/index.tsx
@@ -1,0 +1,24 @@
+import * as S from './Drawer.styled';
+import { useDrawer } from './hooks/useDrawer';
+
+import Icon from '@/components/Icon';
+
+const Drawer = () => {
+  const { isOpen, closeDrawer } = useDrawer();
+
+  return (
+    <S.DrawerLayout className="drawer" $isOpen={isOpen}>
+      <S.Overlay onClick={closeDrawer} $isOpen={isOpen} />
+      <S.Content $isOpen={isOpen}>
+        <Icon icon="Doreburn" width={120} height={15} />
+        <S.ButtonWrapper>
+          <S.Button>주변 둘러보기</S.Button>
+          <S.Button>주간 통계</S.Button>
+          <S.Button>마이 페이지</S.Button>
+        </S.ButtonWrapper>
+      </S.Content>
+    </S.DrawerLayout>
+  );
+};
+
+export default Drawer;

--- a/frontend/src/components/Drawer/index.tsx
+++ b/frontend/src/components/Drawer/index.tsx
@@ -10,7 +10,7 @@ const Drawer = () => {
   const { isOpen, closeDrawer } = useDrawer();
 
   return (
-    <S.DrawerLayout className="drawer" $isOpen={isOpen}>
+    <S.DrawerLayout $isOpen={isOpen}>
       <S.Overlay onClick={closeDrawer} $isOpen={isOpen} />
       <S.Content $isOpen={isOpen}>
         <Icon icon="Doreburn" width={120} height={15} />

--- a/frontend/src/components/Drawer/index.tsx
+++ b/frontend/src/components/Drawer/index.tsx
@@ -1,3 +1,6 @@
+import { Link } from 'react-router';
+
+import { DRAWER_MENU } from './Drawer.constants';
 import * as S from './Drawer.styled';
 import { useDrawer } from './hooks/useDrawer';
 
@@ -11,11 +14,13 @@ const Drawer = () => {
       <S.Overlay onClick={closeDrawer} $isOpen={isOpen} />
       <S.Content $isOpen={isOpen}>
         <Icon icon="Doreburn" width={120} height={15} />
-        <S.ButtonWrapper>
-          <S.Button>주변 둘러보기</S.Button>
-          <S.Button>주간 통계</S.Button>
-          <S.Button>마이 페이지</S.Button>
-        </S.ButtonWrapper>
+        <S.MenuList>
+          {DRAWER_MENU.map((menu, idx) => (
+            <S.MenuItem key={idx}>
+              <Link to={menu.path}>{menu.text}</Link>
+            </S.MenuItem>
+          ))}
+        </S.MenuList>
       </S.Content>
     </S.DrawerLayout>
   );

--- a/frontend/src/components/Header/Header.styled.ts
+++ b/frontend/src/components/Header/Header.styled.ts
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
+export const HeaderContainer = styled.div`
+  position: relative;
+`;
+
 export const HeaderLayout = styled.header`
   display: grid;
   grid-template-columns: auto 1fr 5.2rem;

--- a/frontend/src/components/Header/HeaderButtons/Menu.tsx
+++ b/frontend/src/components/Header/HeaderButtons/Menu.tsx
@@ -1,11 +1,13 @@
-import { BUTTONS } from '../Header.constants';
-
+import { useDrawer } from '@/components/Drawer/hooks/useDrawer';
+import { BUTTONS } from '@/components/Header/Header.constants';
 import * as S from '@/components/Header/Header.styled';
 import Icon, { IconType } from '@/components/Icon';
 
 export const Menu = () => {
+  const { openDrawer } = useDrawer();
+
   return (
-    <S.MenuButton aria-label={BUTTONS.MENU.text}>
+    <S.MenuButton aria-label={BUTTONS.MENU.text} onClick={openDrawer}>
       <Icon icon={BUTTONS.MENU.icon as IconType} />
     </S.MenuButton>
   );

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,14 +1,27 @@
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
-import * as S from './Header.styled';
-import * as Buttons from './HeaderButtons';
+import Drawer from '@/components/Drawer';
+import { DrawerProvider } from '@/components/Drawer/contexts/DrawerProvider';
+import * as S from '@/components/Header/Header.styled';
+import * as Buttons from '@/components/Header/HeaderButtons';
 
 interface HeaderProps {
   children: ReactNode;
 }
 
 const Header = ({ children }: HeaderProps) => {
-  return <S.HeaderLayout>{children}</S.HeaderLayout>;
+  const hasMenuButton = React.Children.toArray(children).some(
+    (child) => React.isValidElement(child) && child.type === Buttons.Menu,
+  );
+
+  const HeaderContent = (
+    <S.HeaderContainer>
+      <S.HeaderLayout>{children}</S.HeaderLayout>
+      {hasMenuButton && <Drawer />}
+    </S.HeaderContainer>
+  );
+
+  return hasMenuButton ? <DrawerProvider>{HeaderContent}</DrawerProvider> : HeaderContent;
 };
 
 Header.Title = ({ children }: { children: ReactNode }) => <S.HeaderTitle>{children}</S.HeaderTitle>;


### PR DESCRIPTION
## Issue Number
close #22

## As-Is
헤더의 메뉴 버튼을 클릭했을 때 Drawer가 열리지 않았음

## To-Be
- [x] Drawer UI 퍼블리싱
- [x] Drawer context를 통한 상태관리
- [x] Drawer 열고 닫기 기능 구현 및 애니메이션 효과 추가

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot
https://github.com/user-attachments/assets/4573c10b-2f49-43ea-941a-551b467a4079

## (Optional) Additional Description

# `Drawer` 상태 관리를 위해 `context`(`DrawerProvider`)를 사용

## `context`를 사용한 이유  

### 1. `useState`를 사용했을 때의 문제점  
`Drawer`의 상태를 전역 또는 특정 페이지에서 관리하는 경우 `props`를 통해 상태와 제어 함수(`open`, `close` 등)를 전달해야 합니다.  
이 과정에서 `props drilling`이 발생합니다.  

- **전역에서 상태를 관리할 경우**: `App` → `Page` → `Header` → `Header.MenuButton`  
- **특정 페이지에서 상태를 관리할 경우**: `Page` → `Header` → `Header.MenuButton`  

Drawer가 필요할 때마다 상태를 전달해야 하기 때문에 코드가 복잡해지고 유지보수가 어려워집니다.

### 2. `context`를 사용한 해결 방식  
`context`를 활용하면 `props`를 전달할 필요 없이 필요한 곳에서만 상태를 공유할 수 있습니다. 

**구현 방식**  
1. `Header` 내부에서 `children`을 확인하여 `MenuButton`이 포함되어 있는지 검사합니다.  
2. `MenuButton`이 존재하면 `DrawerProvider`로 `HeaderContent`를 감싸고, 그렇지 않으면 `Provider` 없이 `HeaderContent`를 반환합니다.  

이를 통해 `Drawer`가 필요한 경우에만 `DrawerProvider`를 적용하여 상태를 관리하므로 불필요한 props drilling을 없애고 상태를 필요한 곳에서만 사용할 수 있습니다. 
 
추가로 현재 구조에서 `Header` 컴포넌트 사용 시 `Drawer` 관련 코드를 작성할 필요가 없어 더욱 간단하게 사용할 수 있습니다.