### PR TITLE
[FEAT] 카카오 로그인 및 회원가입 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.idea/workspace.xml

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 
 	// DB
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation "org.springframework.boot:spring-boot-starter-data-redis"
 	implementation "org.redisson:redisson-spring-boot-starter:3.16.4"
 
 	// test

--- a/backend/src/main/java/com/dubu/backend/BackendApplication.java
+++ b/backend/src/main/java/com/dubu/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.dubu.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/dubu/backend/auth/api/AuthController.java
+++ b/backend/src/main/java/com/dubu/backend/auth/api/AuthController.java
@@ -1,0 +1,47 @@
+package com.dubu.backend.auth.api;
+
+import com.dubu.backend.auth.application.AuthService;
+import com.dubu.backend.auth.domain.OauthProvider;
+import com.dubu.backend.auth.dto.TokenResponse;
+import com.dubu.backend.global.domain.SuccessResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @SneakyThrows
+    @GetMapping("/{oauthProvider}")
+    public void redirectAuthCodeRequestUrl(
+            @PathVariable OauthProvider oauthProvider,
+            HttpServletResponse response
+    ) {
+        String redirectUrl = authService.getAuthCodeRequestUrl(oauthProvider);
+        response.sendRedirect(redirectUrl);
+    }
+
+    @PostMapping("/kakao-login")
+    public SuccessResponse<TokenResponse> kakaoCallback(@RequestBody Map<String, String> request) {
+        String code = request.get("code");
+        TokenResponse response = authService.issueTokenAfterKakaoLogin(code);
+
+        return new SuccessResponse<>(response);
+    }
+
+    @PostMapping("/reissue")
+    public SuccessResponse<TokenResponse> reissue(HttpServletRequest request) {
+        TokenResponse response = authService.reissueToken(request);
+
+        return new SuccessResponse<>(response);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/api/OauthProviderConverter.java
+++ b/backend/src/main/java/com/dubu/backend/auth/api/OauthProviderConverter.java
@@ -1,0 +1,12 @@
+package com.dubu.backend.auth.api;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+import org.springframework.core.convert.converter.Converter;
+
+public class OauthProviderConverter implements Converter<String, OauthProvider> {
+
+    @Override
+    public OauthProvider convert(String source) {
+        return OauthProvider.fromName(source);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/com/dubu/backend/auth/application/AuthService.java
@@ -1,0 +1,43 @@
+package com.dubu.backend.auth.application;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+import com.dubu.backend.auth.domain.authcode.AuthCodeRequestUrlProviderComposite;
+import com.dubu.backend.auth.dto.TokenResponse;
+import com.dubu.backend.auth.infra.oauth.kakao.port.KakaoTokenPort;
+import com.dubu.backend.auth.infra.oauth.kakao.port.KakaoUserPort;
+import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.infrastructure.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final TokenService tokenService;
+    private final KakaoTokenPort kakaoTokenPort;
+    private final KakaoUserPort kakaoUserPort;
+    private final MemberRepository memberRepository;
+    private final AuthCodeRequestUrlProviderComposite authCodeRequestUrlProviderComposite;
+
+    public String getAuthCodeRequestUrl(OauthProvider oauthProvider) {
+        return authCodeRequestUrlProviderComposite.provide(oauthProvider);
+    }
+
+    public TokenResponse reissueToken(HttpServletRequest request) {
+        String newAccessToken = tokenService.reissue(request);
+        return new TokenResponse(newAccessToken);
+    }
+
+    public TokenResponse issueTokenAfterKakaoLogin(String code) {
+        String tokenFromKakao = kakaoTokenPort.getAccessTokenByCode(code);
+        Member kakaoUser = kakaoUserPort.findUserFromKakao(tokenFromKakao);
+        Member loginMember = memberRepository.findByProviderId(kakaoUser.getProviderId())
+                        .orElseGet(() -> memberRepository.save(kakaoUser));
+        String newAccessToken = tokenService.issue(loginMember.getId());
+
+        return new TokenResponse(newAccessToken);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/application/AuthService.java
+++ b/backend/src/main/java/com/dubu/backend/auth/application/AuthService.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -31,6 +32,7 @@ public class AuthService {
         return new TokenResponse(newAccessToken);
     }
 
+    @Transactional
     public TokenResponse issueTokenAfterKakaoLogin(String code) {
         String tokenFromKakao = kakaoTokenPort.getAccessTokenByCode(code);
         Member kakaoUser = kakaoUserPort.findUserFromKakao(tokenFromKakao);

--- a/backend/src/main/java/com/dubu/backend/auth/application/JwtManager.java
+++ b/backend/src/main/java/com/dubu/backend/auth/application/JwtManager.java
@@ -1,0 +1,73 @@
+package com.dubu.backend.auth.application;
+
+import com.dubu.backend.auth.exception.TokenInvalidException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtManager {
+
+    public static final String TOKEN_ISSUER = "DUBU";
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void initKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(Long memberId, long accessTokenTime) {
+        Claims claims = Jwts.claims().subject(memberId.toString()).build();
+        String jti = UUID.randomUUID().toString().substring(0, 16) + memberId;
+        Date now = new Date();
+
+        return Jwts.builder()
+                .id(jti)
+                .issuer(TOKEN_ISSUER)
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + accessTokenTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(Long memberId, long refreshTokenTime) {
+        Claims claims = Jwts.claims().subject(memberId.toString()).build();
+        Date now = new Date();
+
+        return Jwts.builder()
+                .issuer(TOKEN_ISSUER)
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + refreshTokenTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parser()
+                    .requireIssuer(TOKEN_ISSUER)
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException ex) {
+            return ex.getClaims();
+        } catch (JwtException ex) {
+            throw new TokenInvalidException();
+        }
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/application/TokenService.java
+++ b/backend/src/main/java/com/dubu/backend/auth/application/TokenService.java
@@ -62,28 +62,23 @@ public class TokenService {
         return newAccessToken;
     }
 
-    public boolean validateToken(HttpServletRequest request) {
+    public void validateToken(HttpServletRequest request) {
         String token = resolveToken(request);
-        try {
-            Claims claims = jwtManager.parseClaims(token);
-            String jti = claims.getId();
+        Claims claims = jwtManager.parseClaims(token);
+        String jti = claims.getId();
 
-            if (tokenRedisRepository.isBlacklisted(jti)) {
-                throw new TokenBlacklistedException();
-            }
+        if (tokenRedisRepository.isBlacklisted(jti)) {
+            throw new TokenBlacklistedException();
+        }
 
-            String refreshToken = tokenRedisRepository.getRefreshToken(claims.getSubject());
-            if (refreshToken == null) {
-                throw new TokenExpiredException();
-            }
+        String refreshToken = tokenRedisRepository.getRefreshToken(claims.getSubject());
+        if (refreshToken == null) {
+            throw new TokenExpiredException();
+        }
 
-            String existingAccessToken = tokenRedisRepository.getAccessToken(refreshToken);
-            if (existingAccessToken == null || !existingAccessToken.equals(token)) {
-                tokenRedisRepository.addBlacklistToken(jti);
-                throw new TokenInvalidException();
-            }
-            return true;
-        } catch (Throwable exception) {
+        String existingAccessToken = tokenRedisRepository.getAccessToken(refreshToken);
+        if (existingAccessToken == null || !existingAccessToken.equals(token)) {
+            tokenRedisRepository.addBlacklistToken(jti);
             throw new TokenInvalidException();
         }
     }

--- a/backend/src/main/java/com/dubu/backend/auth/application/TokenService.java
+++ b/backend/src/main/java/com/dubu/backend/auth/application/TokenService.java
@@ -1,0 +1,103 @@
+package com.dubu.backend.auth.application;
+
+import com.dubu.backend.auth.exception.*;
+import com.dubu.backend.auth.infra.repository.TokenRedisRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    @Value("${jwt.expire.access-token-in-minutes}")
+    private Duration accessTokenTime;
+    @Value("${jwt.expire.refresh-token-in-minutes}")
+    private Duration refreshTokenTime;
+    private final JwtManager jwtManager;
+    private final TokenRedisRepository tokenRedisRepository;
+
+    public String issue(Long memberId) {
+        String newAccessToken = jwtManager.createAccessToken(memberId, accessTokenTime.toMinutes());
+        String newRefreshToken = jwtManager.createRefreshToken(memberId, refreshTokenTime.toMinutes());
+
+        tokenRedisRepository.saveTokensToRedis(memberId.toString(), newAccessToken, newRefreshToken, refreshTokenTime);
+
+        return newAccessToken;
+    }
+
+    public String reissue(HttpServletRequest request) {
+        String accessToken = resolveToken(request);
+
+        Claims claims = jwtManager.parseClaims(accessToken);
+
+        String jti = claims.getId();
+        String memberId = claims.getSubject();
+
+        if (tokenRedisRepository.isBlacklisted(jti)) {
+            throw new TokenBlacklistedException();
+        }
+
+        String refreshToken = tokenRedisRepository.getRefreshToken(memberId);
+        if (refreshToken == null) {
+            throw new RefreshTokenExpiredException();
+        }
+
+        String existingAccessToken = tokenRedisRepository.getAccessToken(refreshToken);
+        if (existingAccessToken == null || !existingAccessToken.equals(accessToken)) {
+            tokenRedisRepository.addBlacklistToken(jti);
+            throw new TokenInvalidException();
+        }
+
+        tokenRedisRepository.addBlacklistToken(jti);
+
+        String newAccessToken = jwtManager.createAccessToken(Long.parseLong(memberId), accessTokenTime.toMillis());
+
+        tokenRedisRepository.storeAccessToken(refreshToken, newAccessToken, refreshTokenTime);
+
+        return newAccessToken;
+    }
+
+    public boolean validateToken(HttpServletRequest request) {
+        String token = resolveToken(request);
+        try {
+            Claims claims = jwtManager.parseClaims(token);
+            String jti = claims.getId();
+
+            if (tokenRedisRepository.isBlacklisted(jti)) {
+                throw new TokenBlacklistedException();
+            }
+
+            String refreshToken = tokenRedisRepository.getRefreshToken(claims.getSubject());
+            if (refreshToken == null) {
+                throw new TokenExpiredException();
+            }
+
+            String existingAccessToken = tokenRedisRepository.getAccessToken(refreshToken);
+            if (existingAccessToken == null || !existingAccessToken.equals(token)) {
+                tokenRedisRepository.addBlacklistToken(jti);
+                throw new TokenInvalidException();
+            }
+            return true;
+        } catch (Throwable exception) {
+            throw new TokenInvalidException();
+        }
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String jwtToken = request.getHeader("Authorization");
+        if (jwtToken == null) {
+            throw new TokenMissingException();
+        }
+
+        if (jwtToken.startsWith("Bearer ")) {
+            return jwtToken.substring(7);
+        } else {
+            throw new TokenInvalidException();
+        }
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/domain/OauthProvider.java
+++ b/backend/src/main/java/com/dubu/backend/auth/domain/OauthProvider.java
@@ -1,0 +1,11 @@
+package com.dubu.backend.auth.domain;
+
+import static java.util.Locale.ENGLISH;
+
+public enum OauthProvider {
+    KAKAO,
+    ;
+    public static OauthProvider fromName(String type) {
+        return OauthProvider.valueOf(type.toUpperCase(ENGLISH));
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/domain/authcode/AuthCodeRequestUrlProvider.java
+++ b/backend/src/main/java/com/dubu/backend/auth/domain/authcode/AuthCodeRequestUrlProvider.java
@@ -1,0 +1,10 @@
+package com.dubu.backend.auth.domain.authcode;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+
+public interface AuthCodeRequestUrlProvider {
+
+    OauthProvider supportServer();
+
+    String provide();
+}

--- a/backend/src/main/java/com/dubu/backend/auth/domain/authcode/AuthCodeRequestUrlProviderComposite.java
+++ b/backend/src/main/java/com/dubu/backend/auth/domain/authcode/AuthCodeRequestUrlProviderComposite.java
@@ -1,0 +1,35 @@
+package com.dubu.backend.auth.domain.authcode;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+import com.dubu.backend.auth.exception.UnsupportedSocialLoginTypeException;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+@Component
+public class AuthCodeRequestUrlProviderComposite {
+
+    private final Map<OauthProvider, AuthCodeRequestUrlProvider> mapping;
+
+    public AuthCodeRequestUrlProviderComposite(Set<AuthCodeRequestUrlProvider> providers) {
+        mapping = providers.stream()
+                .collect(toMap(
+                        AuthCodeRequestUrlProvider::supportServer,
+                        identity()
+                ));
+    }
+
+    public String provide(OauthProvider oauthProvider) {
+        return getProvider(oauthProvider).provide();
+    }
+
+    private AuthCodeRequestUrlProvider getProvider(OauthProvider oauthProvider) {
+        return Optional.ofNullable(mapping.get(oauthProvider))
+                .orElseThrow(() -> new UnsupportedSocialLoginTypeException());
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/com/dubu/backend/auth/dto/TokenResponse.java
@@ -1,0 +1,7 @@
+package com.dubu.backend.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenResponse(String accessToken) {
+}

--- a/backend/src/main/java/com/dubu/backend/auth/exception/RefreshTokenExpiredException.java
+++ b/backend/src/main/java/com/dubu/backend/auth/exception/RefreshTokenExpiredException.java
@@ -6,7 +6,7 @@ import static com.dubu.backend.global.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
 
 public class RefreshTokenExpiredException extends UnauthorizedException {
     public RefreshTokenExpiredException() {
-        super(REFRESH_TOKEN_EXPIRED.getMessage().formatted());
+        super(REFRESH_TOKEN_EXPIRED.getMessage());
     }
 
     @Override

--- a/backend/src/main/java/com/dubu/backend/auth/exception/RefreshTokenExpiredException.java
+++ b/backend/src/main/java/com/dubu/backend/auth/exception/RefreshTokenExpiredException.java
@@ -1,0 +1,16 @@
+package com.dubu.backend.auth.exception;
+
+import com.dubu.backend.global.exception.UnauthorizedException;
+
+import static com.dubu.backend.global.exception.ErrorCode.REFRESH_TOKEN_EXPIRED;
+
+public class RefreshTokenExpiredException extends UnauthorizedException {
+    public RefreshTokenExpiredException() {
+        super(REFRESH_TOKEN_EXPIRED.getMessage().formatted());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return REFRESH_TOKEN_EXPIRED.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/exception/TokenBlacklistedException.java
+++ b/backend/src/main/java/com/dubu/backend/auth/exception/TokenBlacklistedException.java
@@ -1,0 +1,17 @@
+package com.dubu.backend.auth.exception;
+
+import com.dubu.backend.global.exception.UnauthorizedException;
+
+import static com.dubu.backend.global.exception.ErrorCode.TOKEN_BLACKLISTED;
+
+public class TokenBlacklistedException extends UnauthorizedException {
+
+    public TokenBlacklistedException() {
+        super(TOKEN_BLACKLISTED.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return TOKEN_BLACKLISTED.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/exception/TokenExpiredException.java
+++ b/backend/src/main/java/com/dubu/backend/auth/exception/TokenExpiredException.java
@@ -1,0 +1,17 @@
+package com.dubu.backend.auth.exception;
+
+import com.dubu.backend.global.exception.UnauthorizedException;
+
+import static com.dubu.backend.global.exception.ErrorCode.TOKEN_EXPIRED;
+
+public class TokenExpiredException extends UnauthorizedException {
+
+    public TokenExpiredException() {
+        super(TOKEN_EXPIRED.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return TOKEN_EXPIRED.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/exception/TokenInvalidException.java
+++ b/backend/src/main/java/com/dubu/backend/auth/exception/TokenInvalidException.java
@@ -1,0 +1,17 @@
+package com.dubu.backend.auth.exception;
+
+import com.dubu.backend.global.exception.UnauthorizedException;
+
+import static com.dubu.backend.global.exception.ErrorCode.TOKEN_INVALID;
+
+public class TokenInvalidException extends UnauthorizedException {
+
+    public TokenInvalidException() {
+        super(TOKEN_INVALID.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return TOKEN_INVALID.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/exception/TokenMissingException.java
+++ b/backend/src/main/java/com/dubu/backend/auth/exception/TokenMissingException.java
@@ -1,0 +1,17 @@
+package com.dubu.backend.auth.exception;
+
+import com.dubu.backend.global.exception.UnauthorizedException;
+
+import static com.dubu.backend.global.exception.ErrorCode.TOKEN_MISSING;
+
+public class TokenMissingException extends UnauthorizedException {
+
+    public TokenMissingException() {
+        super(TOKEN_MISSING.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return TOKEN_MISSING.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/exception/UnsupportedSocialLoginTypeException.java
+++ b/backend/src/main/java/com/dubu/backend/auth/exception/UnsupportedSocialLoginTypeException.java
@@ -1,0 +1,16 @@
+package com.dubu.backend.auth.exception;
+
+import com.dubu.backend.global.exception.BadRequestException;
+
+import static com.dubu.backend.global.exception.ErrorCode.UNSUPPORTED_SOCIAL_LOGIN;
+
+public class UnsupportedSocialLoginTypeException extends BadRequestException {
+    public UnsupportedSocialLoginTypeException() {
+        super(UNSUPPORTED_SOCIAL_LOGIN.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return UNSUPPORTED_SOCIAL_LOGIN.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/KakaoOauthConfig.java
+++ b/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/KakaoOauthConfig.java
@@ -1,0 +1,12 @@
+package com.dubu.backend.auth.infra.oauth.kakao;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth2.client.registration.kakao")
+public record KakaoOauthConfig(
+        String redirectUri,
+        String clientId,
+        String clientSecret,
+        String[] scope
+) {
+}

--- a/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/adapter/KakaoAuthCodeHttpClient.java
+++ b/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/adapter/KakaoAuthCodeHttpClient.java
@@ -1,0 +1,31 @@
+package com.dubu.backend.auth.infra.oauth.kakao.adapter;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+import com.dubu.backend.auth.domain.authcode.AuthCodeRequestUrlProvider;
+import com.dubu.backend.auth.infra.oauth.kakao.KakaoOauthConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthCodeHttpClient implements AuthCodeRequestUrlProvider {
+
+    private final KakaoOauthConfig kakaoOauthConfig;
+
+    @Override
+    public OauthProvider supportServer() {
+        return OauthProvider.KAKAO;
+    }
+
+    @Override
+    public String provide() {
+        return UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com/oauth/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", kakaoOauthConfig.clientId())
+                .queryParam("redirect_uri", kakaoOauthConfig.redirectUri())
+                .queryParam("scope", String.join(",", kakaoOauthConfig.scope()))
+                .toUriString();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/adapter/KakaoTokenHttpClient.java
+++ b/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/adapter/KakaoTokenHttpClient.java
@@ -1,0 +1,42 @@
+package com.dubu.backend.auth.infra.oauth.kakao.adapter;
+
+import com.dubu.backend.auth.infra.oauth.kakao.KakaoOauthConfig;
+import com.dubu.backend.auth.infra.oauth.kakao.port.KakaoTokenPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoTokenHttpClient implements KakaoTokenPort {
+
+    private final KakaoOauthConfig kakaoOauthConfig;
+
+    private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+
+    @Override
+    public String getAccessTokenByCode(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoOauthConfig.clientId());
+        params.add("redirect_uri", kakaoOauthConfig.redirectUri());
+        params.add("code", code);
+        params.add("client_secret", kakaoOauthConfig.clientSecret());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(KAKAO_TOKEN_URL, HttpMethod.POST, request, Map.class);
+
+        return (String) response.getBody().get("access_token");
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/adapter/KakaoUserHttpClient.java
+++ b/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/adapter/KakaoUserHttpClient.java
@@ -1,0 +1,50 @@
+package com.dubu.backend.auth.infra.oauth.kakao.adapter;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+import com.dubu.backend.auth.infra.oauth.kakao.port.KakaoUserPort;
+import com.dubu.backend.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoUserHttpClient implements KakaoUserPort {
+
+    private final String KAKAO_USERINFO_API_URL = "https://kapi.kakao.com/v2/user/me";
+
+    @Override
+    public Member findUserFromKakao(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                KAKAO_USERINFO_API_URL,
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        String providerId = (String) response.getBody().get("id");
+        Map kakao_account = (Map) response.getBody().get("kakao_account");
+        Map profile = (Map) kakao_account.get("profile");
+        String nickname = (String) profile.get("nickname");
+        String email = (String) kakao_account.get("email");
+
+        return Member.builder()
+                .nickname(nickname)
+                .email(email)
+                .oauthProvider(OauthProvider.valueOf("KAKAO"))
+                .providerId(providerId)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/port/KakaoTokenPort.java
+++ b/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/port/KakaoTokenPort.java
@@ -1,0 +1,5 @@
+package com.dubu.backend.auth.infra.oauth.kakao.port;
+
+public interface KakaoTokenPort {
+    String getAccessTokenByCode(String code);
+}

--- a/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/port/KakaoUserPort.java
+++ b/backend/src/main/java/com/dubu/backend/auth/infra/oauth/kakao/port/KakaoUserPort.java
@@ -1,0 +1,7 @@
+package com.dubu.backend.auth.infra.oauth.kakao.port;
+
+import com.dubu.backend.member.domain.Member;
+
+public interface KakaoUserPort {
+    Member findUserFromKakao(String accessToken);
+}

--- a/backend/src/main/java/com/dubu/backend/auth/infra/repository/TokenRedisRepository.java
+++ b/backend/src/main/java/com/dubu/backend/auth/infra/repository/TokenRedisRepository.java
@@ -1,0 +1,41 @@
+package com.dubu.backend.auth.infra.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class TokenRedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public TokenRedisRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void saveTokensToRedis(String memberId, String accessToken, String refreshToken, Duration refreshTokenTime) {
+        redisTemplate.opsForValue().set(memberId, refreshToken, refreshTokenTime);
+        redisTemplate.opsForValue().set(refreshToken, accessToken, refreshTokenTime);
+    }
+
+    public String getRefreshToken(String memberId) {
+        return redisTemplate.opsForValue().get(memberId);
+    }
+
+    public String getAccessToken(String refreshToken) {
+        return redisTemplate.opsForValue().get(refreshToken);
+    }
+
+    public void storeAccessToken(String refreshToken, String accessToken, Duration refreshTokenTime) {
+        redisTemplate.opsForValue().set(refreshToken, accessToken, refreshTokenTime);
+    }
+
+    public boolean isBlacklisted(String jti) {
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember("jti:blacklist", jti));
+    }
+
+    public void addBlacklistToken(String jti) {
+        redisTemplate.opsForSet().add("jti:blacklist", jti);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/global/aop/token/TokenValid.java
+++ b/backend/src/main/java/com/dubu/backend/global/aop/token/TokenValid.java
@@ -1,0 +1,11 @@
+package com.dubu.backend.global.aop.token;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TokenValid {
+}

--- a/backend/src/main/java/com/dubu/backend/global/aop/token/TokenValidAspect.java
+++ b/backend/src/main/java/com/dubu/backend/global/aop/token/TokenValidAspect.java
@@ -1,0 +1,27 @@
+package com.dubu.backend.global.aop.token;
+
+import com.dubu.backend.auth.application.TokenService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+public class TokenValidAspect {
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Around("@annotation(TokenValid)")
+    public Object validateToken(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        tokenService.validateToken(request);
+
+        return joinPoint.proceed();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/dubu/backend/global/config/WebConfig.java
@@ -1,7 +1,9 @@
 package com.dubu.backend.global.config;
 
+import com.dubu.backend.auth.api.OauthProviderConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -28,5 +30,9 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("*")
                 .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.PATCH.name(), HttpMethod.DELETE.name());
+    }
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new OauthProviderConverter());
     }
 }

--- a/backend/src/main/java/com/dubu/backend/global/domain/ErrorResponse.java
+++ b/backend/src/main/java/com/dubu/backend/global/domain/ErrorResponse.java
@@ -1,5 +1,8 @@
-package com.dubu.backend.global.exception;
+package com.dubu.backend.global.domain;
 
+import com.dubu.backend.global.exception.BadRequestException;
+import com.dubu.backend.global.exception.ErrorCode;
+import com.dubu.backend.global.exception.UnauthorizedException;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Path;

--- a/backend/src/main/java/com/dubu/backend/global/domain/SuccessResponse.java
+++ b/backend/src/main/java/com/dubu/backend/global/domain/SuccessResponse.java
@@ -1,0 +1,6 @@
+package com.dubu.backend.global.domain;
+
+public record SuccessResponse<D>(
+        D data
+) {
+}

--- a/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     TOKEN_BLACKLISTED(UNAUTHORIZED, "해당 토큰은 사용이 금지되었습니다. 다시 로그인해 주세요."),
     TOKEN_EXPIRED(UNAUTHORIZED, "토큰이 만료되었습니다. 새로운 토큰을 발급받으세요."),
     REFRESH_TOKEN_EXPIRED(UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해 주세요."),
+
+    // OAuth
+    UNSUPPORTED_SOCIAL_LOGIN(BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
     ;
 
     public final HttpStatus httpStatus;

--- a/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
@@ -20,6 +20,13 @@ public enum ErrorCode {
     METHOD_NOT_SUPPORTED(METHOD_NOT_ALLOWED,"허용되지 않은 메서드입니다."),
     MEDIA_TYPE_NOT_SUPPORTED(UNSUPPORTED_MEDIA_TYPE,"허용되지 않은 미디어 타입입니다."),
     SERVER_ERROR(INTERNAL_SERVER_ERROR,"서버 오류가 발생했습니다. 관리자에게 문의하세요."),
+
+    // Token
+    TOKEN_INVALID(UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인해 주세요."),
+    TOKEN_MISSING(UNAUTHORIZED, "토큰이 요청 헤더에 없습니다."),
+    TOKEN_BLACKLISTED(UNAUTHORIZED, "해당 토큰은 사용이 금지되었습니다. 다시 로그인해 주세요."),
+    TOKEN_EXPIRED(UNAUTHORIZED, "토큰이 만료되었습니다. 새로운 토큰을 발급받으세요."),
+    REFRESH_TOKEN_EXPIRED(UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인해 주세요."),
     ;
 
     public final HttpStatus httpStatus;

--- a/backend/src/main/java/com/dubu/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.dubu.backend.global.exception;
 
+import com.dubu.backend.global.domain.ErrorResponse;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;

--- a/backend/src/main/java/com/dubu/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.dubu.backend.global.exception;
 
 import com.dubu.backend.global.domain.ErrorResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.ClientAbortException;
@@ -15,8 +16,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
-@RestControllerAdvice
+@Hidden
 @Slf4j
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler

--- a/backend/src/main/java/com/dubu/backend/member/domain/Member.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/Member.java
@@ -1,0 +1,47 @@
+package com.dubu.backend.member.domain;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+import com.dubu.backend.global.domain.BaseTimeEntity;
+import com.dubu.backend.member.domain.enums.Role;
+import com.dubu.backend.member.domain.enums.Status;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Getter
+@Builder
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OauthProvider oauthProvider;
+
+    private String providerId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'USER'")
+    private Role role;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'STOP'")
+    private Status status;
+
+    private String recentRoute;
+}

--- a/backend/src/main/java/com/dubu/backend/member/domain/enums/Role.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package com.dubu.backend.member.domain.enums;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/backend/src/main/java/com/dubu/backend/member/domain/enums/Status.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/enums/Status.java
@@ -1,0 +1,5 @@
+package com.dubu.backend.member.domain.enums;
+
+public enum Status {
+    STOP, MOVE, FEEDBACK
+}

--- a/backend/src/main/java/com/dubu/backend/member/infrastructure/repository/MemberRepository.java
+++ b/backend/src/main/java/com/dubu/backend/member/infrastructure/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.dubu.backend.member.infrastructure.repository;
+
+import com.dubu.backend.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Integer> {
+    Optional<Member> findByProviderId(String providerId);
+}


### PR DESCRIPTION
## Issue Number
#11 

## As-Is
<!-- 문제 상황 정의 -->
카카오 로그인을 구현한다.

## To-Be
<!-- 변경 사항 -->
- [x] JWT 재발급 처리 API 구현
  - [x] 레디스를 통한 토큰 관리
- [x] OAuth를 통한 카카오 로그인 및 회원가입 처리 API 구현
  - [x] Kakao AuthCode request URL 외부 API 사용
  - [x] Kakao AccessToken 가져오는 외부 API 사용
  - [x] Kakao 로그인한 유저 정보 가져오는 외부 API 사용
- [x] Member 엔티티 및 repository 생성처리
- [x] 공통 성공 응답 추가

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
