### PR TITLE
[FEAT] 출도착지를 통한 대중교통 경로 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/dubu/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/dubu/backend/global/config/WebConfig.java
@@ -38,6 +38,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(tokenInterceptor)
-                .addPathPatterns("/members/**");
+                .addPathPatterns("/members/**")
+                .addPathPatterns("/routes/**");
     }
 }

--- a/backend/src/main/java/com/dubu/backend/member/api/PlaceController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/PlaceController.java
@@ -2,7 +2,7 @@ package com.dubu.backend.member.api;
 
 import com.dubu.backend.global.domain.SuccessResponse;
 import com.dubu.backend.member.application.PlaceService;
-import com.dubu.backend.member.dto.SearchPlaceResponse;
+import com.dubu.backend.member.dto.PlaceSearchResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,10 +19,10 @@ public class PlaceController {
     private final PlaceService placeService;
 
     @GetMapping("/search")
-    public SuccessResponse<List<SearchPlaceResponse>> searchPlaces(
+    public SuccessResponse<List<PlaceSearchResponse>> searchPlaces(
             @RequestParam("query") String query
     ) {
-        List<SearchPlaceResponse> searchPlaces = placeService.searchPlaces(query);
+        List<PlaceSearchResponse> searchPlaces = placeService.searchPlaces(query);
 
         return new SuccessResponse<>(searchPlaces);
     }

--- a/backend/src/main/java/com/dubu/backend/member/application/PlaceService.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/PlaceService.java
@@ -1,9 +1,9 @@
 package com.dubu.backend.member.application;
 
 import com.dubu.backend.member.dto.NaverPlaceApiResponse;
-import com.dubu.backend.member.dto.SearchPlaceResponse;
+import com.dubu.backend.member.dto.PlaceSearchResponse;
 import com.dubu.backend.member.exception.NaverApiServerException;
-import com.dubu.backend.member.infra.place.NaverPlaceApiClient;
+import com.dubu.backend.member.infra.client.NaverPlaceApiClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 public class PlaceService {
     private final NaverPlaceApiClient naverPlaceApiClient;
 
-    public List<SearchPlaceResponse> searchPlaces(String query) {
+    public List<PlaceSearchResponse> searchPlaces(String query) {
         NaverPlaceApiResponse response = naverPlaceApiClient.searchPlaces(query);
 
         if(response == null) {
@@ -23,7 +23,7 @@ public class PlaceService {
         }
 
         return response.places().stream()
-                .map(place -> new SearchPlaceResponse(
+                .map(place -> new PlaceSearchResponse(
                                 place.title().replace("<b>", "").replace("</b>", ""),
                                 place.roadAddress(),
                                 place.mapx() / 1_000_0000.0,

--- a/backend/src/main/java/com/dubu/backend/member/dto/PlaceSearchResponse.java
+++ b/backend/src/main/java/com/dubu/backend/member/dto/PlaceSearchResponse.java
@@ -1,6 +1,6 @@
 package com.dubu.backend.member.dto;
 
-public record SearchPlaceResponse(
+public record PlaceSearchResponse(
         String title,
         String roadAddress,
         Double x_coordinate,

--- a/backend/src/main/java/com/dubu/backend/member/infra/client/NaverApiConfig.java
+++ b/backend/src/main/java/com/dubu/backend/member/infra/client/NaverApiConfig.java
@@ -1,4 +1,4 @@
-package com.dubu.backend.member.infra.place;
+package com.dubu.backend.member.infra.client;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/backend/src/main/java/com/dubu/backend/member/infra/client/NaverPlaceApiClient.java
+++ b/backend/src/main/java/com/dubu/backend/member/infra/client/NaverPlaceApiClient.java
@@ -1,4 +1,4 @@
-package com.dubu.backend.member.infra.place;
+package com.dubu.backend.member.infra.client;
 
 import com.dubu.backend.member.dto.NaverPlaceApiResponse;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/dubu/backend/plan/api/RouteController.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/RouteController.java
@@ -1,0 +1,32 @@
+package com.dubu.backend.plan.api;
+
+
+import com.dubu.backend.global.domain.SuccessResponse;
+import com.dubu.backend.plan.application.RouteService;
+import com.dubu.backend.plan.dto.RouteSearchResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/paths")
+public class RouteController {
+    private final RouteService routeService;
+
+    @GetMapping("/search")
+    public SuccessResponse<List<RouteSearchResponseDto>> routeSearch(
+            @RequestParam(name = "startX") Double startX,
+            @RequestParam(name = "startY") Double startY,
+            @RequestParam(name = "endX") Double endX,
+            @RequestParam(name = "endY") Double endY
+    ) {
+        List<RouteSearchResponseDto> response = routeService.getRoutesByStartAndDestination(startX, startY, endX, endY);
+
+        return new SuccessResponse<>(response);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/api/RouteController.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/RouteController.java
@@ -5,27 +5,25 @@ import com.dubu.backend.global.domain.SuccessResponse;
 import com.dubu.backend.plan.application.RouteService;
 import com.dubu.backend.plan.dto.RouteSearchResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/paths")
+@RequestMapping("/routes")
 public class RouteController {
     private final RouteService routeService;
 
     @GetMapping("/search")
     public SuccessResponse<List<RouteSearchResponseDto>> routeSearch(
-            @RequestParam(name = "startX") Double startX,
-            @RequestParam(name = "startY") Double startY,
-            @RequestParam(name = "endX") Double endX,
-            @RequestParam(name = "endY") Double endY
+            @RequestAttribute("memberId") Long memberId,
+            @RequestParam("startX") Double startX,
+            @RequestParam("startY") Double startY,
+            @RequestParam("endX") Double endX,
+            @RequestParam("endY") Double endY
     ) {
-        List<RouteSearchResponseDto> response = routeService.getRoutesByStartAndDestination(startX, startY, endX, endY);
+        List<RouteSearchResponseDto> response = routeService.getRoutesByStartAndDestination(memberId, startX, startY, endX, endY);
 
         return new SuccessResponse<>(response);
     }

--- a/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
@@ -1,0 +1,100 @@
+package com.dubu.backend.plan.application;
+
+import com.dubu.backend.plan.dto.OdsayRouteApiResponse;
+import com.dubu.backend.plan.dto.RouteSearchResponseDto;
+import com.dubu.backend.plan.infra.client.OdsayApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RouteService {
+    private final OdsayApiClient odsayApiClient;
+
+    /**
+     * 같은 의미인 명칭 정리
+     * 두리번 사용 = ODsay 사용
+     * Route = Path
+     * Path = SubPath
+     */
+    public List<RouteSearchResponseDto> getRoutesByStartAndDestination(Double startX, Double startY, Double endX, Double endY) {
+        OdsayRouteApiResponse odsayRouteApiResponse = odsayApiClient.searchPublicTransportRoute(startX, startY, endX, endY);
+
+        List<RouteSearchResponseDto> response = new ArrayList<>();
+
+        boolean isRecentlyUsed = false;
+
+        for (OdsayRouteApiResponse.Path apiPath : odsayRouteApiResponse.result().path()) {
+            RouteSearchResponseDto routeDto = convertApiPathToRoute(apiPath, isRecentlyUsed);
+            response.add(routeDto);
+        }
+        return response;
+    }
+
+    private RouteSearchResponseDto convertApiPathToRoute(OdsayRouteApiResponse.Path apiPath, boolean isRecentlyUsed) {
+        OdsayRouteApiResponse.Info info = apiPath.info();
+
+        int totalTime = info.totalTime();
+        int totalSectionTime = 0;
+
+        List<RouteSearchResponseDto.Path> pathDtoList = new ArrayList<>();
+
+        // SubPath(=ODsay) → Path(=두리번)Dto 변환
+        for (OdsayRouteApiResponse.SubPath subPath : apiPath.subPath()) {
+            RouteSearchResponseDto.Path dtoPath = convertApiSubPathToPathDto(subPath);
+
+            if ("BUS".equals(dtoPath.trafficType()) || "SUBWAY".equals(dtoPath.trafficType())) {
+                totalSectionTime += dtoPath.sectionTime();
+            }
+            pathDtoList.add(dtoPath);
+        }
+
+        return new RouteSearchResponseDto(isRecentlyUsed, totalTime, totalSectionTime, pathDtoList);
+    }
+
+    private RouteSearchResponseDto.Path convertApiSubPathToPathDto(OdsayRouteApiResponse.SubPath subPath) {
+        int tType = subPath.trafficType();
+        String trafficType = switch (tType) {
+            case 1 -> "SUBWAY";
+            case 2 -> "BUS";
+            case 3 -> "WALK";
+            default -> "UNKNOWN";
+        };
+
+        String subwayName = null;
+        Integer subwayCode = null;
+        String busNumber = null;
+        Integer busCode = null;
+        String startName = null;
+        String endName = null;
+
+        if (subPath.lane() != null && !subPath.lane().isEmpty()) {
+            OdsayRouteApiResponse.Lane lane = subPath.lane().get(0);
+            if ("SUBWAY".equals(trafficType)) {
+                subwayName = lane.name();
+                subwayCode = lane.subwayCode();
+                startName = subPath.startName() + "역";
+                endName = subPath.endName() + "역";
+            } else if ("BUS".equals(trafficType)) {
+                busNumber = lane.busNo();
+                busCode = lane.busID();
+                startName = subPath.startName();
+                endName = subPath.endName();
+            }
+        }
+
+        return new RouteSearchResponseDto.Path(
+                trafficType,
+                subPath.sectionTime(),
+                subwayName,
+                subwayCode,
+                busNumber,
+                busCode,
+                startName,
+                endName
+        );
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
@@ -4,7 +4,7 @@ import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberRepository;
 import com.dubu.backend.plan.domain.Path;
 import com.dubu.backend.plan.domain.Plan;
-import com.dubu.backend.plan.domain.vo.RouteIdentifier;
+import com.dubu.backend.plan.domain.vo.PathIdentifier;
 import com.dubu.backend.plan.dto.OdsayRouteApiResponse;
 import com.dubu.backend.plan.dto.RouteSearchResponseDto;
 import com.dubu.backend.plan.infra.client.OdsayApiClient;
@@ -34,7 +34,7 @@ public class RouteService {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
-        List<RouteIdentifier> recentlyUsedRoute = loadRecentlyUsedRoute(memberId);
+        List<PathIdentifier> recentlyUsedRoute = loadRecentlyUsedRoute(memberId);
 
         OdsayRouteApiResponse odsayRouteApiResponse = odsayApiClient.searchPublicTransportRoute(startX, startY, endX, endY);
 
@@ -48,7 +48,7 @@ public class RouteService {
         return response;
     }
 
-    private List<RouteIdentifier> loadRecentlyUsedRoute(Long memberId) {
+    private List<PathIdentifier> loadRecentlyUsedRoute(Long memberId) {
         Plan latestPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
                 .orElse(null);
 
@@ -63,7 +63,7 @@ public class RouteService {
                     String startName = p.getStartName();
                     String endName = p.getEndName();
 
-                    return new RouteIdentifier(
+                    return new PathIdentifier(
                             p.getTrafficType().name(),
                             startName,
                             endName
@@ -73,8 +73,8 @@ public class RouteService {
     }
 
     private boolean isSameAsRecentlyUsedRoute(OdsayRouteApiResponse.Path apiPath,
-                                              List<RouteIdentifier> recentlyUsedRoute) {
-        List<RouteIdentifier> currentRouteKeys = extractRouteKeys(apiPath);
+                                              List<PathIdentifier> recentlyUsedRoute) {
+        List<PathIdentifier> currentRouteKeys = extractRouteKeys(apiPath);
 
         if (currentRouteKeys.size() != recentlyUsedRoute.size()) {
             return false;
@@ -87,8 +87,8 @@ public class RouteService {
         return true;
     }
 
-    private List<RouteIdentifier> extractRouteKeys(OdsayRouteApiResponse.Path apiPath) {
-        List<RouteIdentifier> result = new ArrayList<>();
+    private List<PathIdentifier> extractRouteKeys(OdsayRouteApiResponse.Path apiPath) {
+        List<PathIdentifier> result = new ArrayList<>();
         for (OdsayRouteApiResponse.SubPath subPath : apiPath.subPath()) {
             int tType = subPath.trafficType();
             if (tType == 1 || tType == 2) {
@@ -100,7 +100,7 @@ public class RouteService {
                     startName += "역";
                     endName += "역";
                 }
-                result.add(new RouteIdentifier(trafficType, startName, endName));
+                result.add(new PathIdentifier(trafficType, startName, endName));
             }
         }
         return result;

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
@@ -1,0 +1,46 @@
+package com.dubu.backend.plan.domain;
+
+import com.dubu.backend.global.domain.BaseTimeEntity;
+import com.dubu.backend.plan.domain.enums.CongestionLevel;
+import com.dubu.backend.plan.domain.enums.TrafficType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"plan_id", "pathOrder"})
+})
+public class Path extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "path_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private Plan plan;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TrafficType trafficType;
+
+    @Column(nullable = false, length = 20)
+    private String startName;
+
+    @Column(nullable = false, length = 20)
+    private String endName;
+
+    @Column(nullable = false, columnDefinition = "SMALLINT")
+    private Integer sectionTime;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private CongestionLevel congestionLevel;
+
+    @Column(nullable = false, columnDefinition = "SMALLINT")
+    private Integer pathOrder;
+}

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Plan.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Plan.java
@@ -1,0 +1,25 @@
+package com.dubu.backend.plan.domain;
+
+import com.dubu.backend.global.domain.BaseTimeEntity;
+import com.dubu.backend.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Plan extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, columnDefinition = "SMALLINT")
+    private Integer totalTime;
+}

--- a/backend/src/main/java/com/dubu/backend/plan/domain/enums/CongestionLevel.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/enums/CongestionLevel.java
@@ -1,0 +1,8 @@
+package com.dubu.backend.plan.domain.enums;
+
+public enum CongestionLevel {
+    RELAXED,
+    NORMAL,
+    BUSY,
+    HIGHLY_BUSY
+}

--- a/backend/src/main/java/com/dubu/backend/plan/domain/enums/TrafficType.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/enums/TrafficType.java
@@ -1,0 +1,5 @@
+package com.dubu.backend.plan.domain.enums;
+
+public enum TrafficType {
+    SUBWAY, BUS
+}

--- a/backend/src/main/java/com/dubu/backend/plan/domain/vo/PathIdentifier.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/vo/PathIdentifier.java
@@ -1,6 +1,6 @@
 package com.dubu.backend.plan.domain.vo;
 
-public record RouteIdentifier(
+public record PathIdentifier(
         String trafficType,
         String startName,
         String endName

--- a/backend/src/main/java/com/dubu/backend/plan/domain/vo/RouteIdentifier.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/vo/RouteIdentifier.java
@@ -1,0 +1,8 @@
+package com.dubu.backend.plan.domain.vo;
+
+public record RouteIdentifier(
+        String trafficType,
+        String startName,
+        String endName
+) {
+}

--- a/backend/src/main/java/com/dubu/backend/plan/dto/OdsayRouteApiResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/OdsayRouteApiResponse.java
@@ -1,0 +1,121 @@
+package com.dubu.backend.plan.dto;
+
+import java.util.List;
+
+public record OdsayRouteApiResponse(
+        Result result
+) {
+    public record Result(
+            int searchType,
+            int outTrafficCheck,
+            int busCount,
+            int subwayCount,
+            int subwayBusCount,
+            double pointDistance,
+            int startRadius,
+            int endRadius,
+            List<Path> path
+    ) {}
+
+    public record Path(
+            int pathType,
+            Info info,
+            List<SubPath> subPath
+    ) {}
+
+    public record Info(
+            double trafficDistance,
+            int totalWalk,
+            int totalTime,
+            int payment,
+            int busTransitCount,
+            int subwayTransitCount,
+            String mapObj,
+            String firstStartStation,
+            String firstStartStationKor,
+            String firstStartStationJpnKata,
+            String lastEndStation,
+            String lastEndStationKor,
+            String lastEndStationJpnKata,
+            int totalStationCount,
+            int busStationCount,
+            int subwayStationCount,
+            double totalDistance,
+            int totalWalkTime,
+            int checkIntervalTime,
+            String checkIntervalTimeOverYn,
+            int totalIntervalTime
+    ) {}
+
+    public record SubPath(
+            int trafficType,
+            double distance,
+            int sectionTime,
+            Integer stationCount,
+            List<Lane> lane,
+            Integer intervalTime,
+            String startName,
+            String startNameKor,
+            String startNameJpnKata,
+            double startX,
+            double startY,
+            String endName,
+            String endNameKor,
+            String endNameJpnKata,
+            double endX,
+            double endY,
+            String way,
+            Integer wayCode,
+            String door,
+            Integer startID,
+            Integer endID,
+            Integer startStationCityCode,
+            Integer startStationProviderCode,
+            String startLocalStationID,
+            String startArsID,
+            Integer endStationCityCode,
+            Integer endStationProviderCode,
+            String endLocalStationID,
+            String endArsID,
+            String startExitNo,
+            Double startExitX,
+            Double startExitY,
+            String endExitNo,
+            Double endExitX,
+            Double endExitY,
+            PassStopList passStopList
+    ) {}
+
+    public record Lane(
+            String name,
+            String nameKor,
+            String nameJpnKata,
+            Integer subwayCode,
+            Integer subwayCityCode,
+            String busNo,
+            String busNoKor,
+            String busNoJpnKata,
+            Integer type,
+            Integer busID,
+            String busLocalBlID,
+            Integer busCityCode,
+            Integer busProviderCode
+    ) {}
+
+    public record PassStopList(List<Station> stations) {}
+
+    public record Station(
+            int index,
+            int stationID,
+            String stationName,
+            String stationNameKor,
+            String stationNameJpnKata,
+            Integer stationCityCode,
+            Integer stationProviderCode,
+            String localStationID,
+            String arsID,
+            String x,
+            String y,
+            String isNonStop
+    ) {}
+}

--- a/backend/src/main/java/com/dubu/backend/plan/dto/RouteSearchResponseDto.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/RouteSearchResponseDto.java
@@ -1,0 +1,22 @@
+package com.dubu.backend.plan.dto;
+
+import java.util.List;
+
+public record RouteSearchResponseDto(
+        Boolean isRecentlyUsed,
+        Integer totalTime,
+        Integer totalSectionTime,
+        List<Path> paths
+) {
+    public record Path(
+            String trafficType,
+            Integer sectionTime,
+            String subwayName,
+            Integer subwayCode,
+            String busNumber,
+            Integer busId,
+            String startName,
+            String endName
+    ) {
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/infra/client/OdsayApiClient.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/client/OdsayApiClient.java
@@ -1,0 +1,30 @@
+package com.dubu.backend.plan.infra.client;
+
+
+import com.dubu.backend.plan.dto.OdsayRouteApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class OdsayApiClient {
+    private final OdsayApiConfig odsayApiConfig;
+
+    public OdsayRouteApiResponse searchPublicTransportRoute(Double startX, Double startY, Double endX, Double endY) {
+        RestClient restClient = RestClient.builder()
+                .baseUrl("https://api.odsay.com/v1/api/searchPubTransPathT")
+                .build();
+
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("apiKey", odsayApiConfig.apiKey())
+                        .queryParam("SX", startX)
+                        .queryParam("SY", startY)
+                        .queryParam("EX", endX)
+                        .queryParam("EY", endY)
+                        .build())
+                .retrieve()
+                .body(OdsayRouteApiResponse.class);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/infra/client/OdsayApiConfig.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/client/OdsayApiConfig.java
@@ -1,0 +1,9 @@
+package com.dubu.backend.plan.infra.client;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "odsay.client")
+public record OdsayApiConfig(
+    String apiKey
+) {
+}

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PathRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PathRepository.java
@@ -1,0 +1,10 @@
+package com.dubu.backend.plan.infra.repository;
+
+import com.dubu.backend.plan.domain.Path;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PathRepository extends JpaRepository<Path, Long> {
+    List<Path> findByPlanIdOrderByPathOrderAsc(Long id);
+}

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
@@ -1,0 +1,10 @@
+package com.dubu.backend.plan.infra.repository;
+
+import com.dubu.backend.plan.domain.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+    Optional<Plan> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
+}


### PR DESCRIPTION
## Issue Number
#42

## As-Is
<!-- 문제 상황 정의 -->
출도착지를 통한 경로 조회 기능 구현합니다.

## To-Be
<!-- 변경 사항 -->
- [x] Plan, Path Entity, Repository 구현
- [x] 출도착지를 통한 경로 조회 API 구현
  - [x] ODsay 대중교통 길찾기 v1.8 API 호출
  - [x] 탐색한 경로 중에서 유저가 최근 이용한 경로가 있는지 체크하는 로직 구현
- [x] ODSay API 설정

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a route search API that lets users obtain public transport routes based on provided start and end coordinates. This update delivers detailed transit information including travel times, traffic modes, and congestion indicators.
- **Refactor**
	- Updated naming conventions for place search responses and streamlined API client integrations for enhanced consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->