### PR TITLE
[FEAT] 인증, 회원, 계획 관련 Swagger 명세 작성

### DIFF
--- a/backend/src/main/java/com/dubu/backend/auth/api/AuthApi.java
+++ b/backend/src/main/java/com/dubu/backend/auth/api/AuthApi.java
@@ -1,0 +1,224 @@
+package com.dubu.backend.auth.api;
+
+import com.dubu.backend.auth.domain.OauthProvider;
+import com.dubu.backend.auth.dto.TokenResponse;
+import com.dubu.backend.global.domain.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public interface AuthApi {
+
+    @Operation(
+            summary = "소셜 로그인 페이지 이동",
+            description = """
+                    oauthProvider 경로 변수를 통해 소셜 로그인 유형(KAKAO)을 선택하고, 
+                    해당 소셜 로그인 인증 페이지로 리다이렉트한다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "302",
+                    description = "소셜 로그인 인증 페이지로 리다이렉트 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "지원하지 않는 소셜 로그인 타입인 경우(UNSUPPORTED_SOCIAL_LOGIN)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "UNSUPPORTED_SOCIAL_LOGIN",
+                                              "message": "지원하지 않는 소셜 로그인 타입입니다."
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    void redirectAuthCodeRequestUrl(
+            @Parameter(
+                    description = "소셜 로그인 제공자(KAKAO 등)",
+                    required = true
+            )
+            OauthProvider oauthProvider,
+            HttpServletResponse response
+    );
+
+    @Operation(
+            summary = "카카오 로그인 콜백 처리",
+            description = """
+                    카카오 로그인 후, 카카오에서 전달받은 인가 코드(code)를 요청 바디로 전송하면 
+                    해당 코드를 사용하여 액세스 토큰을 발급받고 카카오 회원 정보를 조회한 뒤, 
+                    서버 측에서 자체 토큰을 발급한다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "카카오 로그인 성공 후 자체 토큰 발급 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = TokenResponseExample.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "data": {
+                                                "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                              }
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 code 요청 등으로 인한 로그인 실패 가능",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "BAD_REQUEST",
+                                              "message": "로그인 요청이 잘못되었습니다."
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<TokenResponse> kakaoCallback(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "카카오에서 인가 코드를 전달받을 때 사용되는 필드(code)",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = KakaoLoginRequestExample.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "code": "sample_kakao_authorization_code"
+                                            }
+                                            """)
+                            }
+                    )
+            )
+            Map<String, String> request
+    );
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = """
+                    만료된 액세스 토큰을 재발급한다. 
+                    헤더에 Authorization: Bearer {기존 토큰} 을 담아 요청해야 하며, 
+                    서버 내부적으로 Refresh Token 유효성 검사를 수행한다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "액세스 토큰 재발급 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = TokenResponseExample.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "data": {
+                                                "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                              }
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            잘못된 토큰/만료된 토큰/블랙리스트 토큰 등으로 인해 재발급이 불가능한 경우
+                            (TOKEN_MISSING, TOKEN_INVALID, TOKEN_BLACKLISTED, REFRESH_TOKEN_EXPIRED)
+                            """,
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "TOKEN_MISSING",
+                                              "message": "토큰이 요청 헤더에 없습니다."
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "TOKEN_INVALID",
+                                              "message": "유효하지 않은 토큰입니다. 다시 로그인해 주세요."
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "TOKEN_BLACKLISTED",
+                                              "message": "해당 토큰은 사용이 금지되었습니다. 다시 로그인해 주세요."
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "REFRESH_TOKEN_EXPIRED",
+                                              "message": "세션이 만료되었습니다. 다시 로그인해 주세요."
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<TokenResponse> reissue(HttpServletRequest request);
+
+    @Operation(
+            summary = "테스트용 토큰 발급",
+            description = "회원 1번(고정)에 대한 임시 액세스 토큰을 발급한다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "테스트용 토큰 발급 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = TokenResponseExample.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "data": {
+                                                "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                                              }
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<TokenResponse> testToken();
+
+    class ErrorResponseExample {
+        public String errorCode;
+        public String message;
+    }
+
+    class TokenResponseExample {
+        public TokenResponse data;
+    }
+
+    class KakaoLoginRequestExample {
+        public String code;
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/auth/api/AuthController.java
+++ b/backend/src/main/java/com/dubu/backend/auth/api/AuthController.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
-public class AuthController {
+public class AuthController implements AuthApi {
     private final AuthService authService;
 
     @SneakyThrows

--- a/backend/src/main/java/com/dubu/backend/member/api/MemberApi.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/MemberApi.java
@@ -1,0 +1,346 @@
+package com.dubu.backend.member.api;
+
+import com.dubu.backend.global.domain.SuccessResponse;
+import com.dubu.backend.member.dto.request.MemberOnboardingRequest;
+import com.dubu.backend.member.dto.request.MemberStatusUpdateRequest;
+import com.dubu.backend.member.dto.response.MemberSavedAddressResponse;
+import com.dubu.backend.member.dto.response.MemberStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+public interface MemberApi {
+    @Operation(
+            summary = "회원 상태 조회",
+            description = "ONBOARDING, STOP, MOVE, FEEDBACK 4가지 상태에 따라 다른 페이지를 보여주기 위한 회원의 현재 상태(Status)를 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 상태 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = MemberStatusResponse.class,
+                                    description = "회원 상태 정보 응답"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 상태 조회 성공 예시",
+                                            value = """
+                                                    {
+                                                      "data": {
+                                                        "status": "STOP"
+                                                      }
+                                                    }
+                                                    """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원이 존재하지 않는 경우 (MEMBER_NOT_FOUND)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = ErrorResponseExample.class,
+                                    description = "에러 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_NOT_FOUND",
+                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<MemberStatusResponse> getMemberStatus(
+            @Parameter(hidden = true) @RequestAttribute("memberId") Long memberId
+    );
+
+    @Operation(
+            summary = "회원 저장 주소 조회",
+            description = "메인 페이지에서 회원이 저장한 주소 정보(HOME, SCHOOL)를 조회한다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 주소 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = MemberSavedAddressResponse.class,
+                                    description = "회원 주소 정보 응답"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 주소 조회 성공 예시",
+                                            value = """
+                                                    {
+                                                      "data": {
+                                                        "homeAddressName": "서울시 강남구 테헤란로 123",
+                                                        "homeXCoordinate": 127.0276009,
+                                                        "homeYCoordinate": 37.4979421,
+                                                        "schoolAddressName": "서울시 관악구 관악로 1",
+                                                        "schoolXCoordinate": 126.9528804,
+                                                        "schoolYCoordinate": 37.4784966
+                                                      }
+                                                    }
+                                                    """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            다음 경우에 발생할 수 있습니다:
+                            1. 회원을 찾을 수 없는 경우 (MEMBER_NOT_FOUND)
+                            2. 저장된 주소가 없는 경우 (MEMBER_SAVED_ADDRESS_NOT_FOUND)
+                            """,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = ErrorResponseExample.class,
+                                    description = "에러 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_NOT_FOUND",
+                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """),
+                                    @ExampleObject(name = "주소 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_SAVED_ADDRESS_NOT_FOUND",
+                                                      "message": "회원이 저장한 주소를 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<MemberSavedAddressResponse> getMemberSavedAddress(
+            @Parameter(hidden = true) @RequestAttribute("memberId") Long memberId
+    );
+
+    @Operation(
+            summary = "회원 카테고리 조회",
+            description = "할 일 수정 페이지에서 회원이 온보딩 과정에서 선택했던 목표를 보여주기 위해 회원이 추가한 카테고리 목록을 조회한다.\n"
+                    + "6가지 카테고리 존재(READING, HOBBY, ENGLISH, LANGUAGE, NEWS, OTHERS)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 카테고리 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = StringListResponseExample.class,
+                                    description = "카테고리 문자열 배열 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 카테고리 조회 성공 예시",
+                                            value = """
+                                                    {
+                                                      "data": [
+                                                        "READING",
+                                                        "ENGLISH"
+                                                      ]
+                                                    }
+                                                    """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            다음 경우에 발생할 수 있습니다:
+                            1. 회원을 찾을 수 없는 경우 (MEMBER_NOT_FOUND)
+                            2. 회원의 카테고리 정보를 찾을 수 없는 경우 (MEMBER_CATEGORY_NOT_FOUND)
+                            """,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = ErrorResponseExample.class,
+                                    description = "에러 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_NOT_FOUND",
+                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """),
+                                    @ExampleObject(name = "회원 카테고리 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_CATEGORY_NOT_FOUND",
+                                                      "message": "회원의 카테고리 정보를 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<List<String>> getMemberCategory(
+            @Parameter(hidden = true) @RequestAttribute("memberId") Long memberId
+    );
+
+    @Operation(
+            summary = "회원 온보딩 완료",
+            description = "카카오 로그인을 통해 회원을 생성한 이후 추가 정보(카테고리, 주소, 닉네임 등)를 저장하여 온보딩을 완료한다.\n"
+                    + "6가지 카테고리 존재(READING, HOBBY, ENGLISH, LANGUAGE, NEWS, OTHERS)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "온보딩 완료 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            다음 경우에 발생할 수 있습니다:
+                            1. 회원을 찾을 수 없는 경우 (MEMBER_NOT_FOUND)
+                            2. 카테고리를 찾을 수 없는 경우 (CATEGORY_NOT_FOUND)
+                            """,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = ErrorResponseExample.class,
+                                    description = "에러 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 미존재 에러",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_NOT_FOUND",
+                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """),
+                                    @ExampleObject(name = "카테고리 미존재 에러",
+                                            value = """
+                                                    {
+                                                      "errorCode": "CATEGORY_NOT_FOUND",
+                                                      "message": "카테고리를 찾을 수 없습니다. categoryName : ENGLISH"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+    })
+    void completeOnboarding(
+            @Parameter(hidden = true)
+            @RequestAttribute("memberId") Long memberId,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "회원 온보딩 요청 DTO",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = MemberOnboardingRequest.class),
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = {
+                                    @ExampleObject(name = "온보딩 요청 예시",
+                                            value = """
+                                                    {
+                                                      "categories": ["READING", "ENGLISH"],
+                                                      "homeAddress": "서울시 강남구 테헤란로 123",
+                                                      "homeAddressX": 127.0276009,
+                                                      "homeAddressY": 37.4979421,
+                                                      "schoolAddress": "서울시 관악구 관악로 1",
+                                                      "schoolAddressX": 126.9528804,
+                                                      "schoolAddressY": 37.4784966,
+                                                      "nickname": "홍길동"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+            @RequestBody MemberOnboardingRequest request
+    );
+
+    @Operation(
+            summary = "회원 상태 변경",
+            description = """
+                    요청한 값으로 회원의 상태(Status)를 변경한다.
+                    다음 경우에 사용할 수 있습니다:
+                    1. 이동 중 페이지에서 피드백 페이지로 넘어가는 이동완료 버튼을 누를 때 회원의 상태를 MOVE에서 FEEDBACK으로 변경할 때 사용합니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "회원 상태 업데이트 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원이 존재하지 않는 경우 (MEMBER_NOT_FOUND)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = ErrorResponseExample.class,
+                                    description = "에러 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_NOT_FOUND",
+                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+    })
+    void updateMemberStatus(
+            @Parameter(hidden = true)
+            @RequestAttribute("memberId") Long memberId,
+
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "회원 상태 업데이트 요청 DTO",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MemberStatusUpdateRequest.class),
+                            examples = {
+                                    @ExampleObject(name = "회원 상태 업데이트 요청 예시",
+                                            value = """
+                                                    {
+                                                      "status": "FEEDBACK"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+            @RequestBody MemberStatusUpdateRequest request
+    );
+
+    @Schema(name = "ErrorResponseExample", description = "에러 응답 예시")
+    class ErrorResponseExample {
+        @Schema(example = "MEMBER_NOT_FOUND")
+        public String errorCode;
+        @Schema(example = "회원을 찾을 수 없습니다. memberId : 9999")
+        public String message;
+    }
+
+    @Schema(name = "StringListResponseExample", description = "단순 문자열 리스트 예시")
+    class StringListResponseExample {
+        @Schema(example = "[\"READING\", \"ENGLISH\"]")
+        public List<String> data;
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
@@ -16,7 +16,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
-public class MemberController {
+public class MemberController implements MemberApi {
     private final MemberService memberService;
 
     @GetMapping("/status")

--- a/backend/src/main/java/com/dubu/backend/member/api/PlaceApi.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/PlaceApi.java
@@ -1,0 +1,96 @@
+package com.dubu.backend.member.api;
+
+import com.dubu.backend.global.domain.SuccessResponse;
+import com.dubu.backend.member.dto.response.PlaceSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+public interface PlaceApi {
+    @Operation(
+            summary = "장소 검색",
+            description = """
+                          키워드(query)를 이용해 장소를 검색한다. 
+                          내부적으로 네이버 지역 검색 API를 호출한다.
+                          """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "장소 검색 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = PlaceSearchResponseListExample.class,
+                                    description = "장소 검색 결과 리스트"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "장소 검색 성공 예시",
+                                            value = """
+                                                    {
+                                                      "data": [
+                                                        {
+                                                          "title": "카페 홍길동",
+                                                          "roadAddress": "서울특별시 강남구 테헤란로 427",
+                                                          "x_coordinate": 127.0453733,
+                                                          "y_coordinate": 37.5048676
+                                                        },
+                                                        {
+                                                          "title": "카페 이순신",
+                                                          "roadAddress": "서울특별시 강남구 봉은사로 109",
+                                                          "x_coordinate": 127.0594931,
+                                                          "y_coordinate": 37.5057432
+                                                        }
+                                                      ]
+                                                    }
+                                                    """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "503",
+                    description = "네이버 API 서버 장애 (NAVER_SERVICE_UNAVAILABLE)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = ErrorResponseExample.class,
+                                    description = "에러 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "네이버 API 서버 장애 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "NAVER_SERVICE_UNAVAILABLE",
+                                                      "message": "네이버 API 서버가 장애 상태입니다."
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<List<PlaceSearchResponse>> searchPlaces(
+            @Parameter(description = "검색 키워드", required = true, example = "카페")
+            @RequestParam("query") String query
+    );
+
+    @Schema(name = "PlaceSearchResponseListExample", description = "장소 검색 응답 예시")
+    class PlaceSearchResponseListExample {
+        public List<PlaceSearchResponse> data;
+    }
+
+    @Schema(name = "ErrorResponseExample", description = "에러 응답 예시")
+    class ErrorResponseExample {
+        @Schema(example = "NAVER_SERVICE_UNAVAILABLE")
+        public String errorCode;
+        @Schema(example = "네이버 API 서버가 장애 상태입니다.")
+        public String message;
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/member/api/PlaceController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/PlaceController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/places")
-public class PlaceController {
+public class PlaceController implements PlaceApi {
 
     private final PlaceService placeService;
 

--- a/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
@@ -51,6 +51,16 @@ public class MemberService {
         return MemberSavedAddressResponse.from(addresses);
     }
 
+    @Transactional(readOnly = true)
+    public List<String> getMemberCategory(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        return memberCategoryRepository.findMemberCategoriesWithCategoryByMember(member)
+                .stream().map(memberCategory -> memberCategory.getCategory().getName())
+                .toList();
+    }
+
     @Transactional
     public void completeOnboarding(Long memberId, MemberOnboardingRequest request) {
         Member member = memberRepository.findById(memberId)
@@ -87,14 +97,5 @@ public class MemberService {
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
         currentMember.updateStatus(Status.fromString(status));
-    }
-
-    public List<String> getMemberCategory(Long memberId){
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
-
-        return memberCategoryRepository.findMemberCategoriesWithCategoryByMember(member)
-                .stream().map(memberCategory -> memberCategory.getCategory().getName())
-                .toList();
     }
 }

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
@@ -1,0 +1,375 @@
+package com.dubu.backend.plan.api;
+
+import com.dubu.backend.global.domain.SuccessResponse;
+import com.dubu.backend.plan.dto.request.PlanCreateRequest;
+import com.dubu.backend.plan.dto.request.PlanFeedbackCreateRequest;
+import com.dubu.backend.plan.dto.response.FeedbackWritePageInfoResponse;
+import com.dubu.backend.plan.dto.response.PlanRecentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public interface PlanApi {
+
+    @Operation(summary = "계획 생성", description = "선택한 경로를 기반으로 회원의 이동 중 계획을 생성한다. 상태가 STOP인 회원만 생성할 수 있다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "계획 생성 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "회원 상태가 STOP이 아닐 경우(INVALID_MEMBER_STATUS)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "INVALID_MEMBER_STATUS",
+                                              "message": "회원의 상태가 MOVE인 경우 해당 API를 이용할 수 없습니다."
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 또는 스케줄이 존재하지 않을 경우(MEMBER_NOT_FOUND, SCHEDULE_NOT_FOUND)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "MEMBER_NOT_FOUND",
+                                              "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "SCHEDULE_NOT_FOUND",
+                                              "message": "스케줄을 찾을 수 없습니다."
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    void createPlan(
+            @Parameter(hidden = true) @RequestAttribute("memberId") Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "계획 생성 요청 DTO",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PlanCreateRequest.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "totalSectionTime": 40,
+                                              "paths": [
+                                                {
+                                                  "trafficType": "SUBWAY",
+                                                  "sectionTime": 20,
+                                                  "subwayCode": 1002,
+                                                  "busNumber": null,
+                                                  "startName": "선릉",
+                                                  "endName": "역삼"
+                                                },
+                                                {
+                                                  "trafficType": "BUS",
+                                                  "sectionTime": 20,
+                                                  "subwayCode": null,
+                                                  "busNumber": "143",
+                                                  "startName": "역삼",
+                                                  "endName": "강남"
+                                                }
+                                              ]
+                                            }
+                                            """)
+                            }
+                    )
+            )
+            @RequestBody PlanCreateRequest planCreateRequest
+    );
+
+    @Operation(summary = "계획 피드백 생성", description = "이동 완료 후 피드백 페이지에서 이동 중 계획에 대한 피드백을 작성한다. 상태가 FEEDBACK인 회원만 피드백을 작성할 수 있다.\n"
+            + "3가지 상태 존재(DISSATISFIED, MODERATE, SATISFIED)")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "계획 피드백 생성 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "회원 상태가 FEEDBACK이 아닐 경우(INVALID_MEMBER_STATUS) 또는 잘못된 기분 형식(INVALID_MOOD)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "INVALID_MEMBER_STATUS",
+                                              "message": "회원의 상태가 STOP인 경우 해당 API를 이용할 수 없습니다."
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "INVALID_MOOD",
+                                              "message": "유효하지 않은 기분 형식입니다. mood : HAPPY"
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "해당 계획에 대한 접근 권한이 없는 경우(UNAUTHORIZED_PLAN_DELETION)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "UNAUTHORIZED_PLAN_DELETION",
+                                              "message": "회원이 해당 계획에 접근 권한이 없어 삭제할 수 없습니다. memberId : 9999, planId : 1234"
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 또는 계획이 존재하지 않을 경우(MEMBER_NOT_FOUND, NOT_FOUND_PLAN)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "MEMBER_NOT_FOUND",
+                                              "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "NOT_FOUND_PLAN",
+                                              "message": "계획을 찾을 수 없습니다. planId : 1234"
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    void createPlanFeedback(
+            Long memberId,
+            Long planId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "계획 피드백 생성 요청 DTO",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = PlanFeedbackCreateRequest.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "mood": "SATISFIED",
+                                              "memo": "오늘 일정에 만족합니다."
+                                            }
+                                            """)
+                            }
+                    )
+            )
+            PlanFeedbackCreateRequest planFeedbackCreateRequest
+    );
+
+    @Operation(summary = "최근 계획 조회", description = "이동 중 페이지에 접근할 때, 회원이 가장 최근에 생성한 계획에 관한 데이터를 전부 조회한다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "최근 계획 조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = PlanRecentResponse.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "data": {
+                                                "planId": 15,
+                                                "totalSectionTime": 40,
+                                                "createdAt": "2025-02-11T09:00:00",
+                                                "paths": [
+                                                  {
+                                                    "pathId": 101,
+                                                    "trafficType": "SUBWAY",
+                                                    "sectionTime": 20,
+                                                    "subwayCode": 1002,
+                                                    "busNumber": null,
+                                                    "startName": "선릉",
+                                                    "endName": "역삼",
+                                                    "todos": [
+                                                      {
+                                                        "isDone": true,
+                                                        "title": "출근 준비",
+                                                        "category": "OTHERS",
+                                                        "difficulty": "EASY",
+                                                        "memo": null
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 혹은 최근 계획이 존재하지 않을 경우(MEMBER_NOT_FOUND, NOT_FOUND_PLAN)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "MEMBER_NOT_FOUND",
+                                              "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "NOT_FOUND_PLAN",
+                                              "message": "계획을 찾을 수 없습니다."
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<PlanRecentResponse> getRecentPlan(
+            Long memberId
+    );
+
+    @Operation(summary = "피드백 작성 페이지 정보 조회", description = "현재 FEEDBACK 상태에서 작성할 피드백 정보를 조회한다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "피드백 작성 페이지 정보 조회 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = FeedbackWritePageInfoResponse.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "data": {
+                                                "planId": 15,
+                                                "totalSectionTime": 40,
+                                                "totalTodoCount": 3,
+                                                "todos": [
+                                                  {
+                                                    "category": "OTHERS",
+                                                    "title": "조깅 자세 영상 시청"
+                                                  },
+                                                  {
+                                                    "category": "ENGLISH",
+                                                    "title": "영어 단어 암기"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "회원 상태가 FEEDBACK이 아닐 경우(INVALID_MEMBER_STATUS)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "INVALID_MEMBER_STATUS",
+                                              "message": "회원의 상태가 STOP인 경우 해당 API를 이용할 수 없습니다."
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 혹은 계획이 존재하지 않을 경우(MEMBER_NOT_FOUND, NOT_FOUND_PLAN)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "MEMBER_NOT_FOUND",
+                                              "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "NOT_FOUND_PLAN",
+                                              "message": "계획을 찾을 수 없습니다."
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    SuccessResponse<FeedbackWritePageInfoResponse> getFeedbackWritePageInfo(
+            Long memberId
+    );
+
+    @Operation(summary = "계획 삭제", description = "이동 중 페이지에서 이동을 취소할 때, 현재 이용중인 계획을 삭제한다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "계획 삭제 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "해당 계획에 접근 권한이 없는 경우(UNAUTHORIZED_PLAN_DELETION)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "UNAUTHORIZED_PLAN_DELETION",
+                                              "message": "회원이 해당 계획에 접근 권한이 없어 삭제할 수 없습니다. memberId : 9999, planId : 1234"
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원 혹은 계획이 존재하지 않을 경우(MEMBER_NOT_FOUND, NOT_FOUND_PLAN)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "MEMBER_NOT_FOUND",
+                                              "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                            }
+                                            """),
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "NOT_FOUND_PLAN",
+                                              "message": "계획을 찾을 수 없습니다. planId : 1234"
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    void deletePlan(
+            Long memberId,
+            Long planId
+    );
+
+    class ErrorResponseExample {
+        public String errorCode;
+        public String message;
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanController.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/plans")
-public class PlanController {
+public class PlanController implements PlanApi {
     private final PlanService planService;
 
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/com/dubu/backend/plan/api/RouteApi.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/RouteApi.java
@@ -1,0 +1,117 @@
+package com.dubu.backend.plan.api;
+
+import com.dubu.backend.global.domain.SuccessResponse;
+import com.dubu.backend.plan.dto.response.RouteSearchResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+public interface RouteApi {
+
+    @Operation(summary = "경로 검색",
+            description = """
+                    출발지와 도착지의 좌표를 이용하여 대중교통 경로를 검색한다.  
+                    ODsay API를 활용하여 검색된 경로를 반환하며,
+                    최근 사용한 경로 여부(`isRecentlyUsed`)도 함께 제공된다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "경로 검색 성공",
+                    content = @Content(
+                            schema = @Schema(implementation = RouteSearchResponseListExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "data": [
+                                                {
+                                                  "isRecentlyUsed": true,
+                                                  "totalTime": 40,
+                                                  "totalSectionTime": 40,
+                                                  "paths": [
+                                                    {
+                                                      "trafficType": "SUBWAY",
+                                                      "sectionTime": 20,
+                                                      "subwayName": "2호선",
+                                                      "subwayCode": 1002,
+                                                      "busNumber": null,
+                                                      "busId": null,
+                                                      "startName": "선릉역",
+                                                      "endName": "역삼역"
+                                                    },
+                                                    {
+                                                      "trafficType": "BUS",
+                                                      "sectionTime": 20,
+                                                      "subwayName": null,
+                                                      "subwayCode": null,
+                                                      "busNumber": "143",
+                                                      "busId": 300143,
+                                                      "startName": "역삼",
+                                                      "endName": "강남"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원이 존재하지 않을 경우(MEMBER_NOT_FOUND)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(value = """
+                                            {
+                                              "errorCode": "MEMBER_NOT_FOUND",
+                                              "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                            }
+                                            """)
+                            }
+                    )
+            )
+    })
+    @GetMapping("/search")
+    SuccessResponse<List<RouteSearchResponse>> routeSearch(
+            Long memberId,
+            @Parameter(
+                    description = "출발지의 X 좌표(경도)",
+                    example = "127.0276009",
+                    required = true
+            ) Double startX,
+            @Parameter(
+                    description = "출발지의 Y 좌표(위도)",
+                    example = "37.4979421",
+                    required = true
+            ) Double startY,
+            @Parameter(
+                    description = "도착지의 X 좌표(경도)",
+                    example = "126.9783740",
+                    required = true
+            ) Double endX,
+            @Parameter(
+                    description = "도착지의 Y 좌표(위도)",
+                    example = "37.5666103",
+                    required = true
+            ) Double endY
+    );
+
+    class RouteSearchResponseListExample {
+        public List<RouteSearchResponse> data;
+    }
+
+    class ErrorResponseExample {
+        public String errorCode;
+        public String message;
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/api/RouteController.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/RouteController.java
@@ -12,7 +12,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/routes")
-public class RouteController {
+public class RouteController implements RouteApi {
     private final RouteService routeService;
 
     @GetMapping("/search")

--- a/backend/src/main/java/com/dubu/backend/todo/entity/Schedule.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Schedule.java
@@ -23,6 +23,7 @@ public class Schedule extends BaseTimeEntity {
     @Column(name = "date", columnDefinition = "DATE", nullable = false)
     private LocalDate date;
 
+    @Builder.Default
     @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Todo> todos = new ArrayList<>();
 


### PR DESCRIPTION
## Issue Number
#79 

## As-Is
<!-- 문제 상황 정의 -->
인증, 회원, 계획 관련 Swagger 명세를 작성합니다.

## To-Be
<!-- 변경 사항 -->
- [x] Controller를 인터페이스로 분리하여 스웨거 명세 작성
- [x] Auth, Member, Plan, Place, Route API 스워게 명세 작성

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced social login with improved token management.
  - Launched endpoints for managing member data, including status, saved information, and onboarding.
  - Added functionality for place searches, plan management (creation, feedback, deletion, recent retrieval), and route searches based on geographic inputs.

- **Refactor**
  - Standardized controller implementations to align with consistent API contracts.
  - Improved scheduling behavior with robust default task list initialization.

- **Documentation**
  - Upgraded API documentation for clearer and more detailed user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->