### PR TITLE
[FEAT] 사용자 정보 수정 및 조회 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,7 @@ jobs:
               -e JWT_ACCESS_TOKEN_TIME=${{ secrets.JWT_ACCESS_TOKEN_TIME }} \
               -e JWT_REFRESH_TOKEN_TIME=${{ secrets.JWT_REFRESH_TOKEN_TIME }} \
               -e KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }} \
+              -e KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }} \
               -e KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }} \
               -e NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }} \
               -e NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }} \

--- a/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
@@ -2,11 +2,12 @@ package com.dubu.backend.member.api;
 
 import com.dubu.backend.global.domain.SuccessResponse;
 import com.dubu.backend.member.application.MemberService;
+import com.dubu.backend.member.dto.request.MemberInfoUpdateRequest;
 import com.dubu.backend.member.dto.request.MemberOnboardingRequest;
+import com.dubu.backend.member.dto.request.MemberStatusUpdateRequest;
 import com.dubu.backend.member.dto.response.MemberInfoResponse;
 import com.dubu.backend.member.dto.response.MemberSavedAddressResponse;
 import com.dubu.backend.member.dto.response.MemberStatusResponse;
-import com.dubu.backend.member.dto.request.MemberStatusUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -50,7 +51,7 @@ public class MemberController implements MemberApi {
     @GetMapping("/category")
     public SuccessResponse<List<String>> getMemberCategory(
             @RequestAttribute("memberId") Long memberId
-    ){
+    ) {
         return new SuccessResponse<>(memberService.findMemberCategory(memberId));
     }
 
@@ -58,9 +59,19 @@ public class MemberController implements MemberApi {
     @PatchMapping("/onboarding")
     public void completeOnboarding(
             @RequestAttribute("memberId") Long memberId,
-            @RequestBody MemberOnboardingRequest request) {
-
+            @RequestBody MemberOnboardingRequest request
+    ) {
         memberService.completeOnboarding(memberId, request);
+    }
+
+    @PatchMapping
+    public SuccessResponse<MemberInfoResponse> updateMemberInfo(
+            @RequestAttribute("memberId") Long memberId,
+            @RequestBody MemberInfoUpdateRequest request
+    ) {
+        MemberInfoResponse response = memberService.updateMemberInfo(memberId, request);
+
+        return new SuccessResponse<>(response);
     }
 
     @ResponseStatus(NO_CONTENT)

--- a/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
@@ -3,6 +3,7 @@ package com.dubu.backend.member.api;
 import com.dubu.backend.global.domain.SuccessResponse;
 import com.dubu.backend.member.application.MemberService;
 import com.dubu.backend.member.dto.request.MemberOnboardingRequest;
+import com.dubu.backend.member.dto.response.MemberInfoResponse;
 import com.dubu.backend.member.dto.response.MemberSavedAddressResponse;
 import com.dubu.backend.member.dto.response.MemberStatusResponse;
 import com.dubu.backend.member.dto.request.MemberStatusUpdateRequest;
@@ -19,11 +20,20 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 public class MemberController implements MemberApi {
     private final MemberService memberService;
 
+    @GetMapping
+    public SuccessResponse<MemberInfoResponse> getMemberInfo(
+            @RequestAttribute("memberId") Long memberId
+    ) {
+        MemberInfoResponse response = memberService.findMemberInfo(memberId);
+
+        return new SuccessResponse<>(response);
+    }
+
     @GetMapping("/status")
     public SuccessResponse<MemberStatusResponse> getMemberStatus(
             @RequestAttribute("memberId") Long memberId
     ) {
-        MemberStatusResponse response = memberService.getMemberStatus(memberId);
+        MemberStatusResponse response = memberService.findMemberStatus(memberId);
 
         return new SuccessResponse<>(response);
     }
@@ -32,7 +42,7 @@ public class MemberController implements MemberApi {
     public SuccessResponse<MemberSavedAddressResponse> getMemberSavedAddress(
             @RequestAttribute("memberId") Long memberId
     ) {
-        MemberSavedAddressResponse response = memberService.getMemberSavedAddress(memberId);
+        MemberSavedAddressResponse response = memberService.findMemberSavedAddress(memberId);
 
         return new SuccessResponse<>(response);
     }
@@ -41,7 +51,7 @@ public class MemberController implements MemberApi {
     public SuccessResponse<List<String>> getMemberCategory(
             @RequestAttribute("memberId") Long memberId
     ){
-        return new SuccessResponse<>(memberService.getMemberCategory(memberId));
+        return new SuccessResponse<>(memberService.findMemberCategory(memberId));
     }
 
     @ResponseStatus(NO_CONTENT)

--- a/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
@@ -6,6 +6,7 @@ import com.dubu.backend.member.domain.MemberCategory;
 import com.dubu.backend.member.domain.enums.AddressType;
 import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.dto.request.MemberOnboardingRequest;
+import com.dubu.backend.member.dto.response.MemberInfoResponse;
 import com.dubu.backend.member.dto.response.MemberSavedAddressResponse;
 import com.dubu.backend.member.dto.response.MemberStatusResponse;
 import com.dubu.backend.member.exception.MemberNotFoundException;
@@ -13,6 +14,7 @@ import com.dubu.backend.member.exception.MemberSavedAddressNotFoundException;
 import com.dubu.backend.member.infra.repository.AddressRepository;
 import com.dubu.backend.member.infra.repository.MemberCategoryRepository;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.todo.entity.Category;
 import com.dubu.backend.todo.exception.CategoryNotFoundException;
 import com.dubu.backend.todo.repository.CategoryRepository;
@@ -31,7 +33,19 @@ public class MemberService {
     private final AddressRepository addressRepository;
 
     @Transactional(readOnly = true)
-    public MemberStatusResponse getMemberStatus(Long memberId) {
+    public MemberInfoResponse findMemberInfo(Long memberId) {
+        Member currentMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        List<Category> categories = memberCategoryRepository.findCategoriesByMemberId(memberId);
+
+        List<Address> addresses = addressRepository.findByMemberId(memberId);
+
+        return MemberInfoResponse.of(currentMember, categories, addresses);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberStatusResponse findMemberStatus(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
@@ -39,7 +53,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public MemberSavedAddressResponse getMemberSavedAddress(Long memberId) {
+    public MemberSavedAddressResponse findMemberSavedAddress(Long memberId) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
@@ -52,7 +66,7 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public List<String> getMemberCategory(Long memberId){
+    public List<String> findMemberCategory(Long memberId){
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 

--- a/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
@@ -63,15 +63,19 @@ public class MemberService {
 
     @Transactional
     public void completeOnboarding(Long memberId, MemberOnboardingRequest request) {
-        Member member = memberRepository.findById(memberId)
+        Member currentMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        if (currentMember.getStatus() != Status.ONBOARDING) {
+            throw new InvalidMemberStatusException(currentMember.getStatus().name());
+        }
 
         List<MemberCategory> memberCategories = request.categories().stream()
                 .map(categoryName -> {
                     Category category = categoryRepository.findByName(categoryName)
                             .orElseThrow(() -> new CategoryNotFoundException(categoryName));
                     return MemberCategory.builder()
-                            .member(member)
+                            .member(currentMember)
                             .category(category)
                             .build();
                 })
@@ -79,11 +83,11 @@ public class MemberService {
 
         memberCategoryRepository.saveAll(memberCategories);
 
-        saveAddress(member, AddressType.HOME, request.homeAddress(), request.homeAddressX(), request.homeAddressY());
-        saveAddress(member, AddressType.SCHOOL, request.schoolAddress(), request.schoolAddressX(), request.schoolAddressY());
+        saveAddress(currentMember, AddressType.HOME, request.homeAddress(), request.homeAddressX(), request.homeAddressY());
+        saveAddress(currentMember, AddressType.SCHOOL, request.schoolAddress(), request.schoolAddressX(), request.schoolAddressY());
 
-        member.updateNickname(request.nickname());
-        member.updateStatus(Status.STOP);
+        currentMember.updateNickname(request.nickname());
+        currentMember.updateStatus(Status.STOP);
     }
 
     private void saveAddress(Member member, AddressType type, String roadAddress, Double x, Double y) {

--- a/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/MemberService.java
@@ -90,10 +90,10 @@ public class MemberService {
 
         saveMemberCategories(currentMember, request.categories());
 
-        saveAddress(currentMember, AddressType.HOME, request.homeAddress(),
-                request.homeTitle(), request.homeAddressX(), request.homeAddressY());
-        saveAddress(currentMember, AddressType.SCHOOL, request.schoolAddress(),
-                request.schoolTitle(), request.schoolAddressX(), request.schoolAddressY());
+        saveAddress(currentMember, AddressType.HOME, request.homeTitle(),
+                request.homeAddress(), request.homeAddressX(), request.homeAddressY());
+        saveAddress(currentMember, AddressType.SCHOOL, request.schoolTitle(),
+                request.schoolAddress(), request.schoolAddressX(), request.schoolAddressY());
 
         currentMember.updateNickname(request.nickname());
         currentMember.updateStatus(Status.STOP);
@@ -121,7 +121,7 @@ public class MemberService {
             Double x,
             Double y
     ) {
-        Address address = Address.createAddress(member, type, roadAddress, title, x, y);
+        Address address = Address.createAddress(member, type, title, roadAddress, x, y);
         addressRepository.save(address);
     }
 

--- a/backend/src/main/java/com/dubu/backend/member/domain/Address.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/Address.java
@@ -29,6 +29,7 @@ public class Address extends BaseTimeEntity {
     @ColumnDefault("'OTHER'")
     private AddressType addressType;
 
+    @Column(nullable = false)
     private String title;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/dubu/backend/member/domain/Address.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/Address.java
@@ -29,7 +29,7 @@ public class Address extends BaseTimeEntity {
     @ColumnDefault("'OTHER'")
     private AddressType addressType;
 
-    private String name;
+    private String title;
 
     @Column(nullable = false)
     private String roadAddress;
@@ -40,13 +40,21 @@ public class Address extends BaseTimeEntity {
     @Column(nullable = false)
     private Double yCoordinate;
 
-    public static Address createAddress(Member member, AddressType addressType, String roadAddress, Double xCoordinate, Double yCoordinate) {
+    public static Address createAddress(Member member, AddressType addressType, String title, String roadAddress, Double xCoordinate, Double yCoordinate) {
         return Address.builder()
                 .member(member)
+                .title(title)
                 .addressType(addressType)
                 .roadAddress(roadAddress)
                 .xCoordinate(xCoordinate)
                 .yCoordinate(yCoordinate)
                 .build();
+    }
+
+    public void updateAddress(String title, String roadAddress, Double xCoordinate, Double yCoordinate) {
+        this.title = title;
+        this.roadAddress = roadAddress;
+        this.xCoordinate = xCoordinate;
+        this.yCoordinate = yCoordinate;
     }
 }

--- a/backend/src/main/java/com/dubu/backend/member/domain/MemberCategory.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/MemberCategory.java
@@ -17,6 +17,7 @@ public class MemberCategory extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_category_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/dubu/backend/member/dto/request/MemberInfoUpdateRequest.java
+++ b/backend/src/main/java/com/dubu/backend/member/dto/request/MemberInfoUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.dubu.backend.member.dto.request;
+
+import java.util.List;
+
+public record MemberInfoUpdateRequest(
+        List<String> categories,
+        String homeTitle,
+        String homeAddress,
+        double homeAddressX,
+        double homeAddressY,
+        String schoolTitle,
+        String schoolAddress,
+        double schoolAddressX,
+        double schoolAddressY
+) {
+}

--- a/backend/src/main/java/com/dubu/backend/member/dto/request/MemberOnboardingRequest.java
+++ b/backend/src/main/java/com/dubu/backend/member/dto/request/MemberOnboardingRequest.java
@@ -4,9 +4,11 @@ import java.util.List;
 
 public record MemberOnboardingRequest(
         List<String> categories,
+        String homeTitle,
         String homeAddress,
         double homeAddressX,
         double homeAddressY,
+        String schoolTitle,
         String schoolAddress,
         double schoolAddressX,
         double schoolAddressY,

--- a/backend/src/main/java/com/dubu/backend/member/dto/response/MemberInfoResponse.java
+++ b/backend/src/main/java/com/dubu/backend/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,12 @@
+package com.dubu.backend.member.dto.response;
+
+import java.util.List;
+
+public record MemberInfoResponse(
+        String email,
+        String nickName,
+        List<String> categories,
+        String homeAddress,
+        String schoolAddress
+) {
+}

--- a/backend/src/main/java/com/dubu/backend/member/dto/response/MemberInfoResponse.java
+++ b/backend/src/main/java/com/dubu/backend/member/dto/response/MemberInfoResponse.java
@@ -9,21 +9,21 @@ import java.util.List;
 
 public record MemberInfoResponse(
         String email,
-        String nickName,
+        String nickname,
         List<String> categories,
-        String homeAddress,
-        String schoolAddress
+        String homeTitle,
+        String schoolTitle
 ) {
     public static MemberInfoResponse of(Member member, List<Category> categories, List<Address> addresses) {
-        String homeAddress = addresses.stream()
+        String homeTitle = addresses.stream()
                 .filter(address -> address.getAddressType() == AddressType.HOME)
-                .map(Address::getRoadAddress)
+                .map(Address::getTitle)
                 .findFirst()
                 .orElse(null);
 
-        String schoolAddress = addresses.stream()
+        String schoolTitle = addresses.stream()
                 .filter(address -> address.getAddressType() == AddressType.SCHOOL)
-                .map(Address::getRoadAddress)
+                .map(Address::getTitle)
                 .findFirst()
                 .orElse(null);
 
@@ -31,8 +31,8 @@ public record MemberInfoResponse(
                 member.getEmail(),
                 member.getNickname(),
                 categories.stream().map(Category::getName).toList(),
-                homeAddress,
-                schoolAddress
+                homeTitle,
+                schoolTitle
         );
     }
 }

--- a/backend/src/main/java/com/dubu/backend/member/dto/response/MemberInfoResponse.java
+++ b/backend/src/main/java/com/dubu/backend/member/dto/response/MemberInfoResponse.java
@@ -1,5 +1,10 @@
 package com.dubu.backend.member.dto.response;
 
+import com.dubu.backend.member.domain.Address;
+import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.AddressType;
+import com.dubu.backend.todo.entity.Category;
+
 import java.util.List;
 
 public record MemberInfoResponse(
@@ -9,4 +14,25 @@ public record MemberInfoResponse(
         String homeAddress,
         String schoolAddress
 ) {
+    public static MemberInfoResponse of(Member member, List<Category> categories, List<Address> addresses) {
+        String homeAddress = addresses.stream()
+                .filter(address -> address.getAddressType() == AddressType.HOME)
+                .map(Address::getRoadAddress)
+                .findFirst()
+                .orElse(null);
+
+        String schoolAddress = addresses.stream()
+                .filter(address -> address.getAddressType() == AddressType.SCHOOL)
+                .map(Address::getRoadAddress)
+                .findFirst()
+                .orElse(null);
+
+        return new MemberInfoResponse(
+                member.getEmail(),
+                member.getNickname(),
+                categories.stream().map(Category::getName).toList(),
+                homeAddress,
+                schoolAddress
+        );
+    }
 }

--- a/backend/src/main/java/com/dubu/backend/member/dto/response/MemberSavedAddressResponse.java
+++ b/backend/src/main/java/com/dubu/backend/member/dto/response/MemberSavedAddressResponse.java
@@ -6,10 +6,10 @@ import com.dubu.backend.member.domain.enums.AddressType;
 import java.util.List;
 
 public record MemberSavedAddressResponse(
-    String homeAddressName,
+    String homeTitle,
     Double homeXCoordinate,
     Double homeYCoordinate,
-    String schoolAddressName,
+    String schoolTitle,
     Double schoolXCoordinate,
     Double schoolYCoordinate
 ) {
@@ -25,10 +25,10 @@ public record MemberSavedAddressResponse(
                 .orElse(null);
 
         return new MemberSavedAddressResponse(
-                homeAddress != null ? homeAddress.getRoadAddress() : null,
+                homeAddress != null ? homeAddress.getTitle() : null,
                 homeAddress != null ? homeAddress.getXCoordinate() : null,
                 homeAddress != null ? homeAddress.getYCoordinate() : null,
-                schoolAddress != null ? schoolAddress.getRoadAddress() : null,
+                schoolAddress != null ? schoolAddress.getTitle() : null,
                 schoolAddress != null ? schoolAddress.getXCoordinate() : null,
                 schoolAddress != null ? schoolAddress.getYCoordinate() : null
         );

--- a/backend/src/main/java/com/dubu/backend/member/infra/repository/MemberCategoryRepository.java
+++ b/backend/src/main/java/com/dubu/backend/member/infra/repository/MemberCategoryRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface MemberCategoryRepository extends JpaRepository<MemberCategory, Long> {
+    List<MemberCategory> findByMemberId(Long memberId);
+
     @Query("SELECT mc.category FROM MemberCategory mc WHERE mc.member.id = :memberId")
     List<Category> findCategoriesByMemberId(@Param("memberId") Long memberId);
 

--- a/backend/src/main/java/com/dubu/backend/member/infra/repository/MemberCategoryRepository.java
+++ b/backend/src/main/java/com/dubu/backend/member/infra/repository/MemberCategoryRepository.java
@@ -2,6 +2,7 @@ package com.dubu.backend.member.infra.repository;
 
 import com.dubu.backend.member.domain.Member;
 import com.dubu.backend.member.domain.MemberCategory;
+import com.dubu.backend.todo.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,6 +10,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface MemberCategoryRepository extends JpaRepository<MemberCategory, Long> {
+    @Query("SELECT mc.category FROM MemberCategory mc WHERE mc.member.id = :memberId")
+    List<Category> findCategoriesByMemberId(@Param("memberId") Long memberId);
+
     @Query("SELECT mc.category.id FROM MemberCategory mc WHERE mc.member = :member")
     List<Long> findCategoryIdsByMember(@Param("member") Member member);
 

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -40,7 +40,7 @@ oauth2:
     registration:
       kakao:
         client_id: ${KAKAO_CLIENT_ID} # REST API
-        redirect_uri: http://localhost:3000/oauth/redirected/kakao
+        redirect_uri: ${KAKAO_REDIRECT_URI}
         client_secret: ${KAKAO_CLIENT_SECRET} # Client Secret
         scope: profile_nickname, profile_image
     provider:

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -27,7 +27,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     open-in-view: false
 
   servlet:


### PR DESCRIPTION
## Issue Number
#75

## As-Is
<!-- 문제 상황 정의 -->
사용자 정보 수정 및 조회 기능 구현합니다.

## To-Be
<!-- 변경 사항 -->
- [x] 사용자 정보 수정 API 구현
- [x] 사용자 정보 조회 API 구현
- [x] 응답 DTO 네이밍 변경(name -> title)
- [x] KAKAO_REDIRECT_URI 시크릿 설정
- [x] 추가된 API 스웨거 명세 작성

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced profile endpoints to view and update member details, including refined address and category information.
  - Added a new environment variable for deployment to improve configuration flexibility.
  - Upgraded the onboarding process with additional fields for home and school address titles.

- **Chores**
  - Improved deployment configuration with dynamic OAuth2 redirect settings for a more flexible production environment.

- **Refactor**
  - Streamlined member status and address handling for clearer, more consistent profile management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->