### PR TITLE
[REFACTOR] 할 일 관련 기능 1차 리팩토링

### DIFF
--- a/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
     TODO_NOT_FOUND(NOT_FOUND, "해당 할 일이 존재하지 않습니다."),
     ALREADY_ADDED_TODO(BAD_REQUEST, "이미 추가된 할 일 입니다."),
     TODO_LIMIT_EXCEEDED(BAD_REQUEST, "%s 할 일은 최대 %d 개까지 추가할 수 있습니다."),
+    TODO_TYPE_MISMATCH(BAD_REQUEST, "할 일의 타입과 요청 타입이 일치하지 않습니다. 할 일 타입 = %s, 요청 타입 = %s"),
 
     INVALID_TODO_REQUEST_TYPE(BAD_REQUEST, "잘못된 할 일 요청 유형입니다. type = %s"),
 

--- a/backend/src/main/java/com/dubu/backend/todo/controller/TodoController.java
+++ b/backend/src/main/java/com/dubu/backend/todo/controller/TodoController.java
@@ -70,10 +70,12 @@ public class TodoController implements TodoApi{
         TodoManagementService todoManagementService = todoManagementServiceRegistry.getService(type.getManagementServiceName());
         TodoManageResult<?> result = todoManagementService.modifyTodo(new TodoIdentifier(memberId, todoId, null), request);
 
-        if(result.isTomorrowScheduleCreated())
-            return ResponseEntity.status(HttpStatus.CREATED).body(new TodoSuccessResponse<>(true, result.info()));
+        Boolean isTomorrowScheduleCreated = result.isTomorrowScheduleCreated();
 
-        return ResponseEntity.status(HttpStatus.OK).body(new TodoSuccessResponse<>(false, result.info()));
+        if(isTomorrowScheduleCreated == null || !isTomorrowScheduleCreated)
+            return ResponseEntity.status(HttpStatus.OK).body(new TodoSuccessResponse<>(isTomorrowScheduleCreated, result.info()));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(new TodoSuccessResponse<>(true, result.info()));
     }
 
     @DeleteMapping("/{todoId}")
@@ -85,7 +87,13 @@ public class TodoController implements TodoApi{
         TodoManagementService todoManagementService = todoManagementServiceRegistry.getService(type.getManagementServiceName());
         TodoManageResult<?> result = todoManagementService.removeTodo(new TodoIdentifier(memberId, todoId, null));
 
-        if(result.isTomorrowScheduleCreated())
+        Boolean isTomorrowScheduleCreated = result.isTomorrowScheduleCreated();
+
+        if(isTomorrowScheduleCreated == null){
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+
+        if(isTomorrowScheduleCreated)
             return ResponseEntity.status(HttpStatus.CREATED).body(new TodoSuccessResponse<>(true, result.info()));
 
         return ResponseEntity.status(HttpStatus.OK).body(new TodoSuccessResponse<>(false, result.info()));

--- a/backend/src/main/java/com/dubu/backend/todo/dto/response/TodoManageResult.java
+++ b/backend/src/main/java/com/dubu/backend/todo/dto/response/TodoManageResult.java
@@ -1,8 +1,8 @@
 package com.dubu.backend.todo.dto.response;
 
-public record TodoManageResult<D>(boolean isTomorrowScheduleCreated, D info) {
+public record TodoManageResult<D>(Boolean isTomorrowScheduleCreated, D info) {
 
-    public static<D> TodoManageResult<D> of(boolean isTomorrowScheduleCreated, D info){
+    public static<D> TodoManageResult<D> of(Boolean isTomorrowScheduleCreated, D info){
         return new TodoManageResult<D>(isTomorrowScheduleCreated, info);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/todo/dto/response/TodoSuccessResponse.java
+++ b/backend/src/main/java/com/dubu/backend/todo/dto/response/TodoSuccessResponse.java
@@ -1,4 +1,6 @@
 package com.dubu.backend.todo.dto.response;
 
-public record TodoSuccessResponse<D>(boolean isTomorrowScheduleCreated, D data) {
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record TodoSuccessResponse<D>(@JsonInclude(JsonInclude.Include.NON_NULL) Boolean isTomorrowScheduleCreated, D data) {
 }

--- a/backend/src/main/java/com/dubu/backend/todo/exception/TodoTypeMismatchException.java
+++ b/backend/src/main/java/com/dubu/backend/todo/exception/TodoTypeMismatchException.java
@@ -1,0 +1,17 @@
+package com.dubu.backend.todo.exception;
+
+import com.dubu.backend.global.exception.BadRequestException;
+import com.dubu.backend.todo.entity.TodoType;
+
+import static com.dubu.backend.global.exception.ErrorCode.*;
+
+public class TodoTypeMismatchException extends BadRequestException {
+    public TodoTypeMismatchException(TodoType todoType, TodoType requestType) {
+        super(TODO_TYPE_MISMATCH.getMessage().formatted(todoType.name(), requestType.name()));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return TODO_TYPE_MISMATCH.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoManagementService.java
@@ -1,9 +1,11 @@
 package com.dubu.backend.todo.service.impl;
 
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberRepository;
 import com.dubu.backend.plan.domain.Path;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.plan.exception.PathNotFoundException;
 import com.dubu.backend.plan.infra.repository.PathRepository;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
@@ -41,6 +43,12 @@ public class PathTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> createTodo(TodoIdentifier identifier, TodoCreateRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태가 이동 중 이어야 한다.
+        if(!member.getStatus().equals(Status.MOVE)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Path path = pathRepository.findById(identifier.pathId()).orElseThrow(() -> new PathNotFoundException(identifier.pathId()));
         Category category = categoryRepository.findByName(todoCreateRequest.category()).orElseThrow(() -> new CategoryNotFoundException(todoCreateRequest.category()));
 
@@ -78,6 +86,12 @@ public class PathTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> modifyTodo(TodoIdentifier identifier, TodoUpdateRequest todoUpdateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태가 이동 중 이어야 한다.
+        if(!member.getStatus().equals(Status.MOVE)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo todo = todoRepository.findWithCategoryById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
         // 제목, 카테고리, 난이도 수정 시 부모 할 일 관계 끊기
@@ -103,6 +117,12 @@ public class PathTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> removeTodo(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태가 이동 중 이어야 한다.
+        if(!member.getStatus().equals(Status.MOVE)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo todo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
         todoRepository.delete(todo);

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoManagementService.java
@@ -58,7 +58,7 @@ public class PathTodoManagementService implements TodoManagementService {
         Todo todo = todoCreateRequest.toEntity(member, category, null, path, TodoType.IN_PROGRESS);
         Todo savedTodo = todoRepository.save(todo);
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(savedTodo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(savedTodo));
     }
 
     @Override
@@ -83,7 +83,7 @@ public class PathTodoManagementService implements TodoManagementService {
         Todo todo = Todo.of(parentTodo.getTitle(), TodoType.IN_PROGRESS, parentTodo.getDifficulty(), parentTodo.getMemo(), member, parentTodo.getCategory(), parentTodo, null, path);
         Todo savedTodo = todoRepository.save(todo);
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(savedTodo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(savedTodo));
     }
 
     @Override
@@ -120,7 +120,7 @@ public class PathTodoManagementService implements TodoManagementService {
 
         todo.updateTodo(todoUpdateRequest.title(), category, difficulty, todoUpdateRequest.memo());
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(todo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(todo));
     }
 
     @Override
@@ -141,6 +141,6 @@ public class PathTodoManagementService implements TodoManagementService {
 
         todoRepository.delete(todo);
 
-        return TodoManageResult.of(false, null);
+        return TodoManageResult.of(null, null);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoQueryService.java
@@ -46,9 +46,11 @@ public class PathTodoQueryService implements TargetTodoQueryService {
     public List<TodoInfo> findTargetTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        if(member.getStatus() != Status.MOVE){
+        // 회원의 상태가 이동 중 이어야 한다.
+        if(!member.getStatus().equals(Status.MOVE)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
+
         Path path = pathRepository.findById(identifier.pathId()).orElseThrow(() -> new PathNotFoundException(identifier.pathId()));
 
         List<Todo> todos = todoRepository.findTodosWithCategoryByPath(path);
@@ -59,6 +61,12 @@ public class PathTodoQueryService implements TargetTodoQueryService {
     @Override
     public PageResponse<Long, List<TodoInfo>> findSaveTodos(TodoIdentifier identifier, Long cursor, SaveTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태가 이동 중 이어야 한다.
+        if(!member.getStatus().equals(Status.MOVE)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Path path = pathRepository.findById(identifier.pathId()).orElseThrow(() -> new PathNotFoundException(identifier.pathId()));
 
         Slice<Todo> todoSlice = todoRepository.findTodosUsingSingleCursor(cursor,
@@ -91,6 +99,12 @@ public class PathTodoQueryService implements TargetTodoQueryService {
     @Override
     public List<TodoInfo> findPersonalizedRecommendTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태가 이동 중 이어야 한다.
+        if(!member.getStatus().equals(Status.MOVE)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Path path = pathRepository.findById(identifier.pathId()).orElseThrow(() -> new PathNotFoundException(identifier.pathId()));
 
         // 회원의 카테고리 정보에 해당하는 추천 할 일을 가져온다.
@@ -115,6 +129,12 @@ public class PathTodoQueryService implements TargetTodoQueryService {
     @Override
     public PageResponse<Cursor, List<TodoInfo>> findAllRecommendTodos(TodoIdentifier identifier, Cursor cursor, RecommendTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태가 이동 중 이어야 한다.
+        if(!member.getStatus().equals(Status.MOVE)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Path path = pathRepository.findById(identifier.pathId()).orElseThrow(() -> new PathNotFoundException(identifier.pathId()));
 
         List<Category> categories = null;

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
@@ -1,8 +1,10 @@
 package com.dubu.backend.todo.service.impl;
 
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.request.TodoCreateFromArchivedRequest;
 import com.dubu.backend.todo.dto.request.TodoCreateRequest;
@@ -36,6 +38,11 @@ public class SaveTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> createTodo(TodoIdentifier identifier, TodoCreateRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
         Category category = categoryRepository.findByName(todoCreateRequest.category()).orElseThrow(() -> new CategoryNotFoundException(todoCreateRequest.category()));
 
         Todo todo = todoCreateRequest.toEntity(member, category, null, null, TodoType.SAVE);
@@ -47,6 +54,12 @@ public class SaveTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> createTodoFromArchived(TodoIdentifier identifier, TodoCreateFromArchivedRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo parentTodo = todoRepository.findWithCategoryById(todoCreateRequest.todoId()).orElseThrow(TodoNotFoundException::new);
 
         todoRepository.findByMemberAndParentTodoAndType(member, parentTodo, TodoType.SAVE).ifPresent(todo -> {throw new AlreadyAddedTodoFromArchivedException();});
@@ -60,6 +73,12 @@ public class SaveTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> modifyTodo(TodoIdentifier identifier, TodoUpdateRequest todoUpdateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo todo = todoRepository.findWithCategoryById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
         // 제목, 카테고리, 난이도를 수정하는 경우 관련된 부모 할 일 삭제
@@ -94,6 +113,12 @@ public class SaveTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> removeTodo(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo todo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
         // 즐겨찾기 할 일로 부터 생성된 오늘 할 일, 내일 할 일의 부모 id 제거

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
@@ -45,7 +45,7 @@ public class SaveTodoManagementService implements TodoManagementService {
         Todo todo = todoCreateRequest.toEntity(member, category, null, null, TodoType.SAVE);
         Todo savedTodo = todoRepository.save(todo);
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(savedTodo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(savedTodo));
     }
 
     @Override
@@ -64,7 +64,7 @@ public class SaveTodoManagementService implements TodoManagementService {
         Todo todo = Todo.of(parentTodo.getTitle(), TodoType.SAVE, parentTodo.getDifficulty(), parentTodo.getMemo(), member, parentTodo.getCategory(), parentTodo, null, null);
         Todo savedTodo = todoRepository.save(todo);
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(savedTodo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(savedTodo));
     }
 
     @Override
@@ -109,7 +109,7 @@ public class SaveTodoManagementService implements TodoManagementService {
 
         todo.updateTodo(todoUpdateRequest.title(), category, difficulty, todoUpdateRequest.memo());
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(todo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(todo));
     }
 
     @Override
@@ -136,6 +136,6 @@ public class SaveTodoManagementService implements TodoManagementService {
 
         todoRepository.delete(todo);
 
-        return TodoManageResult.of(false, null);
+        return TodoManageResult.of(null, null);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
@@ -12,10 +12,7 @@ import com.dubu.backend.todo.dto.request.TodoUpdateRequest;
 import com.dubu.backend.todo.dto.response.TodoInfo;
 import com.dubu.backend.todo.dto.response.TodoManageResult;
 import com.dubu.backend.todo.entity.*;
-import com.dubu.backend.todo.exception.AlreadyAddedTodoFromArchivedException;
-import com.dubu.backend.todo.exception.CategoryNotFoundException;
-import com.dubu.backend.todo.exception.ScheduleNotFoundException;
-import com.dubu.backend.todo.exception.TodoNotFoundException;
+import com.dubu.backend.todo.exception.*;
 import com.dubu.backend.todo.repository.CategoryRepository;
 import com.dubu.backend.todo.repository.ScheduleRepository;
 import com.dubu.backend.todo.repository.TodoRepository;
@@ -81,6 +78,11 @@ public class SaveTodoManagementService implements TodoManagementService {
 
         Todo todo = todoRepository.findWithCategoryById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
+        // 할 일 타입과 요청 타입이 일치하지 않는다면
+        if (!todo.getType().equals(TodoType.SAVE)){
+            throw new TodoTypeMismatchException(todo.getType(), TodoType.SAVE);
+        }
+
         // 제목, 카테고리, 난이도를 수정하는 경우 관련된 부모 할 일 삭제
         if(todoUpdateRequest.title() != null || todoUpdateRequest.category() != null || todoUpdateRequest.difficulty() != null){
             // 내일 할 일 관련
@@ -120,6 +122,11 @@ public class SaveTodoManagementService implements TodoManagementService {
         }
 
         Todo todo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
+
+        // 할 일 타입과 요청 타입이 일치하지 않는다면
+        if (!todo.getType().equals(TodoType.SAVE)){
+            throw new TodoTypeMismatchException(todo.getType(), TodoType.SAVE);
+        }
 
         // 즐겨찾기 할 일로 부터 생성된 오늘 할 일, 내일 할 일의 부모 id 제거
         todoRepository.findWithScheduleByParentTodoAndScheduleDate(todo, LocalDate.now().plusDays(1)).ifPresent(Todo::clearParentTodo);

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoQueryService.java
@@ -2,9 +2,11 @@ package com.dubu.backend.todo.service.impl;
 
 import com.dubu.backend.global.domain.PageResponse;
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberCategoryRepository;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.todo.dto.common.Cursor;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.request.RecommendTodoQueryRequest;
@@ -40,6 +42,10 @@ public class SaveTodoQueryService implements TodoQueryService {
     public PageResponse<Long, List<TodoInfo>> findSaveTodos(TodoIdentifier identifier, Long cursor, SaveTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
         Slice<Todo> todoSlice = todoRepository.findTodosUsingSingleCursor(cursor,
                 TodoSearchCond.builder()
                         .member(member)
@@ -61,6 +67,10 @@ public class SaveTodoQueryService implements TodoQueryService {
     public List<TodoInfo> findPersonalizedRecommendTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
         // 회원의 카테고리 정보에 해당하는 추천 할 일을 가져온다.
         List<Long> categoryIds = memberCategoryRepository.findCategoryIdsByMember(member);
         List<Todo> recommendTodos = todoRepository.findTodosWithCategoryByCategoryIdsAndType(categoryIds, TodoType.RECOMMEND);
@@ -83,6 +93,11 @@ public class SaveTodoQueryService implements TodoQueryService {
     @Override
     public PageResponse<Cursor, List<TodoInfo>> findAllRecommendTodos(TodoIdentifier identifier, Cursor cursor, RecommendTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
 
         List<Category> categories = null;
         if(request.category() != null && !request.category().isEmpty()){

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
@@ -1,8 +1,10 @@
 package com.dubu.backend.todo.service.impl;
 
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.request.TodoCreateFromArchivedRequest;
 import com.dubu.backend.todo.dto.request.TodoCreateRequest;
@@ -33,6 +35,12 @@ public class TodayTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> createTodo(TodoIdentifier identifier, TodoCreateRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Category category = categoryRepository.findByName(todoCreateRequest.category()).orElseThrow(() -> new CategoryNotFoundException(todoCreateRequest.category()));
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
 
@@ -48,6 +56,12 @@ public class TodayTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> createTodoFromArchived(TodoIdentifier identifier, TodoCreateFromArchivedRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
 
         if(schedule.getTodos().size() == 3){
@@ -67,6 +81,12 @@ public class TodayTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> modifyTodo(TodoIdentifier identifier, TodoUpdateRequest todoUpdateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo todo = todoRepository.findWithCategoryById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
         // 제목, 카테고리, 난이도 수정 시 부모 할 일 관계 끊기
@@ -92,6 +112,12 @@ public class TodayTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> removeTodo(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo todo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
         todoRepository.delete(todo);

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
@@ -50,7 +50,7 @@ public class TodayTodoManagementService implements TodoManagementService {
 
         Todo todo = todoCreateRequest.toEntity(member, category, schedule, null, TodoType.SCHEDULED);
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(todoRepository.save(todo)));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(todoRepository.save(todo)));
     }
 
     @Override
@@ -75,7 +75,7 @@ public class TodayTodoManagementService implements TodoManagementService {
         Todo newTodo = Todo.of(parentTodo.getTitle(), TodoType.SCHEDULED, parentTodo.getDifficulty(), parentTodo.getMemo(), member, parentTodo.getCategory(), parentTodo, schedule, null);
 
         Todo savedTodo = todoRepository.save(newTodo);
-        return TodoManageResult.of(false, TodoInfo.fromEntity(savedTodo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(savedTodo));
     }
 
     @Override
@@ -111,7 +111,7 @@ public class TodayTodoManagementService implements TodoManagementService {
 
         todo.updateTodo(todoUpdateRequest.title(), category, difficulty, todoUpdateRequest.memo());
 
-        return TodoManageResult.of(false, TodoInfo.fromEntity(todo));
+        return TodoManageResult.of(null, TodoInfo.fromEntity(todo));
     }
 
     @Override
@@ -132,6 +132,6 @@ public class TodayTodoManagementService implements TodoManagementService {
 
         todoRepository.delete(todo);
 
-        return TodoManageResult.of(false, null);
+        return TodoManageResult.of(null, null);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
@@ -89,6 +89,11 @@ public class TodayTodoManagementService implements TodoManagementService {
 
         Todo todo = todoRepository.findWithCategoryById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
 
+        // 할 일 타입과 요청 타입이 일치하지 않는다면
+        if (!todo.getType().equals(TodoType.SCHEDULED)){
+            throw new TodoTypeMismatchException(todo.getType(), TodoType.SCHEDULED);
+        }
+
         // 제목, 카테고리, 난이도 수정 시 부모 할 일 관계 끊기
         if(todoUpdateRequest.title() != null || todoUpdateRequest.category() != null || todoUpdateRequest.difficulty() != null){
             todo.clearParentTodo();
@@ -119,6 +124,11 @@ public class TodayTodoManagementService implements TodoManagementService {
         }
 
         Todo todo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
+
+        // 할 일 타입과 요청 타입이 일치하지 않는다면
+        if (!todo.getType().equals(TodoType.SCHEDULED)){
+            throw new TodoTypeMismatchException(todo.getType(), TodoType.SCHEDULED);
+        }
 
         todoRepository.delete(todo);
 

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoQueryService.java
@@ -2,10 +2,12 @@ package com.dubu.backend.todo.service.impl;
 
 import com.dubu.backend.global.domain.PageResponse;
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberCategoryNotFoundException;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberCategoryRepository;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.todo.dto.common.Cursor;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.request.RecommendTodoQueryRequest;
@@ -46,6 +48,11 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
     public List<TodoInfo> findTargetTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule todaySchedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseGet(() -> {
             Schedule newSchedule = Schedule.of(LocalDate.now(), member);
             List<Long> categoryIds = memberCategoryRepository.findCategoryIdsByMember(member);
@@ -73,6 +80,12 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
     @Override
     public PageResponse<Long, List<TodoInfo>> findSaveTodos(TodoIdentifier identifier, Long cursor, SaveTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
 
         Slice<Todo> todoSlice = todoRepository.findTodosUsingSingleCursor(cursor,
@@ -105,6 +118,12 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
     @Override
     public List<TodoInfo> findPersonalizedRecommendTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
 
         // 회원의 카테고리 정보에 해당하는 추천 할 일을 가져온다.
@@ -129,6 +148,12 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
     @Override
     public PageResponse<Cursor, List<TodoInfo>> findAllRecommendTodos(TodoIdentifier identifier, Cursor cursor, RecommendTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
 
         List<Category> categories = null;

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoManagementService.java
@@ -1,8 +1,10 @@
 package com.dubu.backend.todo.service.impl;
 
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.request.TodoCreateFromArchivedRequest;
 import com.dubu.backend.todo.dto.request.TodoCreateRequest;
@@ -37,6 +39,12 @@ public class TomorrowTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> createTodo(TodoIdentifier identifier, TodoCreateRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Category category = categoryRepository.findByName(todoCreateRequest.category()).orElseThrow(() -> new CategoryNotFoundException(todoCreateRequest.category()));
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
@@ -67,6 +75,12 @@ public class TomorrowTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> createTodoFromArchived(TodoIdentifier identifier, TodoCreateFromArchivedRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
         List<Todo> todos = todoRepository.findTodosWithCategoryBySchedule(schedule);
@@ -100,6 +114,12 @@ public class TomorrowTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> modifyTodo(TodoIdentifier identifier, TodoUpdateRequest todoUpdateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo targetTodo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
@@ -151,6 +171,12 @@ public class TomorrowTodoManagementService implements TodoManagementService {
     @Override
     public TodoManageResult<?> removeTodo(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Todo targetTodo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoManagementService.java
@@ -121,6 +121,12 @@ public class TomorrowTodoManagementService implements TodoManagementService {
         }
 
         Todo targetTodo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
+
+        // 할 일 타입과 요청 타입이 일치하지 않는다면
+        if (!targetTodo.getType().equals(TodoType.SCHEDULED)){
+            throw new TodoTypeMismatchException(targetTodo.getType(), TodoType.SCHEDULED);
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
         List<Todo> tomorrowTodos = null;
@@ -178,6 +184,12 @@ public class TomorrowTodoManagementService implements TodoManagementService {
         }
 
         Todo targetTodo = todoRepository.findById(identifier.todoId()).orElseThrow(TodoNotFoundException::new);
+
+        // 할 일 타입과 요청 타입이 일치하지 않는다면
+        if (!targetTodo.getType().equals(TodoType.SCHEDULED)){
+            throw new TodoTypeMismatchException(targetTodo.getType(), TodoType.SCHEDULED);
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
         // 내일 스케줄이 없는 경우

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoQueryService.java
@@ -2,9 +2,11 @@ package com.dubu.backend.todo.service.impl;
 
 import com.dubu.backend.global.domain.PageResponse;
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberCategoryRepository;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.todo.dto.common.Cursor;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.request.RecommendTodoQueryRequest;
@@ -43,6 +45,12 @@ public class TomorrowTodoQueryService implements TargetTodoQueryService {
     @Override
     public List<TodoInfo> findTargetTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
         List<Todo> todos = todoRepository.findTodosWithCategoryBySchedule(schedule);
@@ -52,6 +60,12 @@ public class TomorrowTodoQueryService implements TargetTodoQueryService {
     @Override
     public PageResponse<Long, List<TodoInfo>> findSaveTodos(TodoIdentifier identifier, Long cursor, SaveTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
         Slice<Todo> todoSlice = todoRepository.findTodosUsingSingleCursor(cursor,
@@ -84,6 +98,12 @@ public class TomorrowTodoQueryService implements TargetTodoQueryService {
     @Override
     public List<TodoInfo> findPersonalizedRecommendTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
         // 회원의 카테고리 정보에 해당하는 추천 할 일을 가져온다.
@@ -108,6 +128,12 @@ public class TomorrowTodoQueryService implements TargetTodoQueryService {
     @Override
     public PageResponse<Cursor, List<TodoInfo>> findAllRecommendTodos(TodoIdentifier identifier, Cursor cursor, RecommendTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        // 회원의 상태는 정지여야 한다.
+        if(!member.getStatus().equals(Status.STOP)){
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now().plusDays(1)).orElseThrow(ScheduleNotFoundException::new);
 
         List<Category> categories = null;


### PR DESCRIPTION
## Issue Number
close #88 

## As-Is
<!-- 문제 상황 정의 -->
할 일 관련 기능 1차 리팩토링
## To-Be
<!-- 변경 사항 -->

- [x] api 응답 바디 값을 수정한다.

    - [x] 할 일 변경 모든 요청에 내일 스케줄의 생성 여부 데이터를 포함시켰지만 내일 할 일 변경 요청에만 포함시키고 나머지는 제외시킨다.

- [x] 할 일 관련 비즈니스 로직에 사용자의 상태를 확인하는 로직을 추가한다.

- [x] 할 일 수정, 삭제 시 해당 할 일의 타입과 요청 타입이 같은지를 확인하는 로직을 추가한다.

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an improved error response for task type mismatches, providing clearer feedback when operations do not meet expected criteria.
  - Added enhanced validations for user status, ensuring that task operations only proceed when the user is in an eligible state.

- **Refactor**
  - Streamlined response handling in task operations for more accurate HTTP statuses based on scheduling and modification results.
  - Updated response data formatting to more consistently handle optional values during serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->