### PR TITLE
[FEAT] 대시보드 기능 구현 

### DIFF
--- a/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
@@ -6,6 +6,7 @@ import com.dubu.backend.plan.dto.request.PlanCreateRequest;
 import com.dubu.backend.todo.entity.Todo;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +29,7 @@ public class Path extends BaseTimeEntity {
     @JoinColumn(name = "plan_id", nullable = false)
     private Plan plan;
 
+    @BatchSize(size = 100)
     @Builder.Default
     @OneToMany(mappedBy = "path", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Todo> todos = new ArrayList<>();

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Plan.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Plan.java
@@ -30,6 +30,9 @@ public class Plan extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "SMALLINT")
     private Integer totalTime;
 
+    @OneToOne(mappedBy = "plan")
+    private Feedback feedback;
+
     public static Plan createPlan(Member member, Integer totalTime) {
         return Plan.builder()
                 .member(member)

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
@@ -1,10 +1,26 @@
 package com.dubu.backend.plan.infra.repository;
 
+import com.dubu.backend.member.domain.Member;
 import com.dubu.backend.plan.domain.Plan;
+import com.dubu.backend.todo.entity.TodoType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     Optional<Plan> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    @Query("SELECT p FROM Plan p " +
+            "JOIN FETCH p.feedback " +
+            "JOIN FETCH p.paths pa " +
+            "JOIN pa.todos t " +
+            "WHERE p.member = :member AND t.type = :type AND p.createdAt between :startTime AND :endTime"
+    )
+    List<Plan> findByMemberAndTypeAndCreatedAtBetween(Member member, TodoType type, LocalDateTime startTime, LocalDateTime endTime);
+
+    @Query("SELECT p FROM Plan p JOIN FETCH p.feedback WHERE p.member = :member AND p.createdAt between :startTime AND :endTime")
+    List<Plan> findByMemberAndCreatedAtBetween(Member member, LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/backend/src/main/java/com/dubu/backend/statistic/controller/StatisticController.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/controller/StatisticController.java
@@ -1,0 +1,34 @@
+package com.dubu.backend.statistic.controller;
+
+import com.dubu.backend.global.domain.SuccessResponse;
+import com.dubu.backend.statistic.dto.response.DayStatisticInfo;
+import com.dubu.backend.statistic.dto.response.WeekStatisticInfo;
+import com.dubu.backend.statistic.service.StatisticService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/statistics")
+@RequiredArgsConstructor
+public class StatisticController {
+    private final StatisticService statisticService;
+
+    @GetMapping("/day")
+    public SuccessResponse<DayStatisticInfo> getDayStatistic(
+            @RequestAttribute Long memberId,
+            @RequestParam LocalDate date
+            )
+    {
+        return new SuccessResponse<>(statisticService.collectDayStatistic(memberId, date));
+    }
+
+    @GetMapping("/week")
+    public SuccessResponse<WeekStatisticInfo> getWeekStatistic(
+            @RequestAttribute Long memberId,
+            @RequestParam LocalDate startDate
+    ){
+        return new SuccessResponse<>(statisticService.collectWeekStatistic(memberId, startDate));
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/statistic/dto/response/CategoryTodoInfo.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/dto/response/CategoryTodoInfo.java
@@ -1,0 +1,20 @@
+package com.dubu.backend.statistic.dto.response;
+
+import java.util.List;
+import java.util.Map;
+
+public record CategoryTodoInfo(String category, int count) implements Comparable<CategoryTodoInfo>{
+    @Override
+    public int compareTo(CategoryTodoInfo other) {
+        return Integer.compare(other.count, this.count);
+    }
+
+    public static List<CategoryTodoInfo> fromCategoryTodoCount(Map<String, Integer> categoryTodoCount){
+        return categoryTodoCount.entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() > 0)
+                .map(entry -> new CategoryTodoInfo(entry.getKey(), entry.getValue()))
+                .sorted()
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/statistic/dto/response/DayStatisticInfo.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/dto/response/DayStatisticInfo.java
@@ -1,0 +1,31 @@
+package com.dubu.backend.statistic.dto.response;
+
+import com.dubu.backend.plan.domain.Feedback;
+
+import java.util.List;
+import java.util.Map;
+
+public record DayStatisticInfo(
+        int totalMoveTime,
+        int totalUsageTime,
+        List<FeedbackInfo> feedbacks,
+        List<CategoryTodoInfo> categoryTodoCounts
+) {
+    public static DayStatisticInfo of(int totalMoveTime, int totalUsageTime, List<Feedback> feedbacks, Map<String, Integer> categoryTodoCount){
+
+        return new DayStatisticInfo(
+                totalMoveTime,
+                totalUsageTime,
+                FeedbackInfo.fromFeedbacks(feedbacks),
+                CategoryTodoInfo.fromCategoryTodoCount(categoryTodoCount)
+        );
+    }
+
+    public record FeedbackInfo(String mood, String memo) {
+        public static List<FeedbackInfo> fromFeedbacks(List<Feedback> feedbacks){
+            return feedbacks.stream()
+                    .map(f -> new FeedbackInfo(f.getMood().name(), f.getMemo()))
+                    .toList();
+        }
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/statistic/dto/response/WeekStatisticInfo.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/dto/response/WeekStatisticInfo.java
@@ -1,0 +1,34 @@
+package com.dubu.backend.statistic.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record WeekStatisticInfo(
+        List<DayUsageTime> dayUsageTimes,
+        int totalTodoCount,
+        int lastWeekDiff,
+        int totalMoveTime,
+        int totalUsageTime,
+        List<CategoryTodoInfo> categoryTodoCounts
+) {
+    public static WeekStatisticInfo of(Map<LocalDate, Integer> dateUsageTime, int totalTodoCount, int lastWeekDiff, int totalMoveTime, int totalUsageTime, Map<String, Integer> categoryTodoCount){
+        return new WeekStatisticInfo(
+                DayUsageTime.fromDateUsageTime(dateUsageTime),
+                totalTodoCount,
+                lastWeekDiff,
+                totalMoveTime,
+                totalUsageTime,
+                CategoryTodoInfo.fromCategoryTodoCount(categoryTodoCount)
+        );
+    }
+
+    record DayUsageTime(LocalDate date, int usageTime){
+        private static List<DayUsageTime> fromDateUsageTime(Map<LocalDate, Integer> dateUsageTime){
+            return dateUsageTime.entrySet()
+                            .stream()
+                            .map(entry -> new DayUsageTime(entry.getKey(), entry.getValue()))
+                            .toList();
+        }
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/statistic/service/StatisticService.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/service/StatisticService.java
@@ -1,0 +1,11 @@
+package com.dubu.backend.statistic.service;
+
+import com.dubu.backend.statistic.dto.response.DayStatisticInfo;
+import com.dubu.backend.statistic.dto.response.WeekStatisticInfo;
+
+import java.time.LocalDate;
+
+public interface StatisticService {
+    DayStatisticInfo collectDayStatistic(Long memberId, LocalDate date);
+    WeekStatisticInfo collectWeekStatistic(Long memberId, LocalDate date);
+}

--- a/backend/src/main/java/com/dubu/backend/statistic/service/collection/CategoryTodoStatistics.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/service/collection/CategoryTodoStatistics.java
@@ -1,0 +1,22 @@
+package com.dubu.backend.statistic.service.collection;
+
+import com.dubu.backend.todo.entity.Category;
+import com.dubu.backend.todo.entity.Todo;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+public class CategoryTodoStatistics {
+    private final Map<String, Integer> categoryTodoCount;
+
+    public CategoryTodoStatistics(List<Category> categories) {
+        this.categoryTodoCount = categories.stream().collect(Collectors.toMap(Category::getName, category -> 0));
+    }
+
+    public void countDoneTodoByCategory(Todo todo){
+        categoryTodoCount.merge(todo.getCategory().getName(), 1, Integer::sum);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/statistic/service/collection/DateUsageTimeStatistics.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/service/collection/DateUsageTimeStatistics.java
@@ -1,0 +1,26 @@
+package com.dubu.backend.statistic.service.collection;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Getter
+public class DateUsageTimeStatistics {
+    private final Map<LocalDate, Integer> dateUsageTime;
+
+    public DateUsageTimeStatistics(LocalDate startDate) {
+        dateUsageTime = IntStream.range(0, 7)
+                .boxed()
+                .collect(Collectors.toMap(
+                        i -> startDate.plusDays(i),
+                        i -> 0
+                ));
+    }
+
+    public void addUsageTimeAtDate(LocalDate date, int time){
+        dateUsageTime.merge(date, time, Integer::sum);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
@@ -1,0 +1,114 @@
+package com.dubu.backend.statistic.service.impl;
+
+import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.exception.MemberNotFoundException;
+import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.domain.Feedback;
+import com.dubu.backend.plan.domain.Path;
+import com.dubu.backend.plan.domain.Plan;
+import com.dubu.backend.plan.infra.repository.PlanRepository;
+import com.dubu.backend.statistic.dto.response.DayStatisticInfo;
+import com.dubu.backend.statistic.dto.response.WeekStatisticInfo;
+import com.dubu.backend.statistic.service.StatisticService;
+import com.dubu.backend.statistic.service.collection.CategoryTodoStatistics;
+import com.dubu.backend.statistic.service.collection.DateUsageTimeStatistics;
+import com.dubu.backend.todo.entity.Category;
+import com.dubu.backend.todo.entity.Todo;
+import com.dubu.backend.todo.entity.TodoType;
+import com.dubu.backend.todo.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticServiceImpl implements StatisticService {
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+    private final PlanRepository planRepository;
+
+    @Override
+    public DayStatisticInfo collectDayStatistic(Long memberId, LocalDate date) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+        List<Category> categories = categoryRepository.findAll();
+        List<Plan> dayPlans = planRepository.findByMemberAndTypeAndCreatedAtBetween(member, TodoType.DONE, date.atStartOfDay(), date.atTime(LocalTime.MAX));
+
+        if(dayPlans == null || dayPlans.isEmpty()){
+            return null;
+        }
+
+        return buildDailyStatisticInfo(categories, dayPlans);
+    }
+
+    @Override
+    public WeekStatisticInfo collectWeekStatistic(Long memberId, LocalDate date) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+        List<Category> categories = categoryRepository.findAll();
+
+        List<Plan> thisWeekPlans = planRepository.findByMemberAndTypeAndCreatedAtBetween(member, TodoType.DONE, date.atStartOfDay(), date.plusWeeks(1).atTime(LocalTime.MAX));
+
+        if(thisWeekPlans == null || thisWeekPlans.isEmpty()){
+            return null;
+        }
+
+        List<Plan> lastWeekPlans = planRepository.findByMemberAndCreatedAtBetween(member, date.minusWeeks(1).atStartOfDay(), date.minusDays(1).atTime(LocalTime.MAX));
+
+        return buildWeekStatisticInfo(date, categories, thisWeekPlans, lastWeekPlans);
+    }
+
+
+    private DayStatisticInfo buildDailyStatisticInfo(List<Category> categories, List<Plan> plans) {
+        int totalMoveTime = 0;
+        int totalUsageTime = 0;
+        List<Feedback> feedbacks = new ArrayList<>();
+        CategoryTodoStatistics categoryTodoStatistics = new CategoryTodoStatistics(categories);
+
+        for(Plan plan: plans){
+            totalMoveTime += plan.getTotalTime();
+            feedbacks.add(plan.getFeedback());
+
+           for(Path path: plan.getPaths()){
+                for(Todo todo: path.getTodos()){
+                    categoryTodoStatistics.countDoneTodoByCategory(todo);
+                    totalUsageTime += todo.getSpentTime();
+                }
+            }
+        }
+
+        return DayStatisticInfo.of(totalMoveTime, totalUsageTime, feedbacks, categoryTodoStatistics.getCategoryTodoCount());
+    }
+
+    private WeekStatisticInfo buildWeekStatisticInfo(LocalDate startDate, List<Category> categories, List<Plan> thisWeekPlans, List<Plan> lastWeekPlans){
+        DateUsageTimeStatistics dateUsageTimeStatistics = new DateUsageTimeStatistics(startDate);
+        int totalMoveTime = 0;
+        int totalUsageTime = 0;
+        int totalTodoCount = 0;
+        CategoryTodoStatistics categoryTodoStatistics = new CategoryTodoStatistics(categories);
+
+        for(Plan plan: thisWeekPlans){
+            dateUsageTimeStatistics.addUsageTimeAtDate(plan.getCreatedAt().toLocalDate(), plan.getTotalTime());
+            totalMoveTime += plan.getTotalTime();
+
+            for(Path path: plan.getPaths()){
+                for(Todo todo: path.getTodos()){
+                    totalTodoCount += 1;
+                    categoryTodoStatistics.countDoneTodoByCategory(todo);
+                    totalUsageTime += todo.getSpentTime();
+                }
+            }
+        }
+        int lastWeekDiff = totalUsageTime - calculateWeeklyUsageTime(lastWeekPlans);
+
+        return WeekStatisticInfo.of(dateUsageTimeStatistics.getDateUsageTime(), totalTodoCount, lastWeekDiff, totalMoveTime, totalUsageTime, categoryTodoStatistics.getCategoryTodoCount());
+    }
+
+    private int calculateWeeklyUsageTime(List<Plan> plans){
+        return plans.stream().mapToInt(Plan::getTotalTime).sum();
+    }
+}


### PR DESCRIPTION
## Issue Number

close #95 
## As-Is
<!-- 문제 상황 정의 -->
일일 통계 조회 기능을 구현한다.

주간 통계 조회 기능을 구현한다.
## To-Be
<!-- 변경 사항 -->
- [x] 일일, 주간 통계 조회 기능을 구현한다.
    - [x] 총 활용 시간 계산
    - [x] 카테고리별 한 할 일의 수를 계산하여 정렬
    - [x] 주간 통계의 경우 일일의 활용 시간 계산
    - [x] 주간 통계의 경우 저번 주와의 활용 시간 비교
- [x] MultipleBagFetchException 해결
   - [x] 페치 조인(1번) + Batchsize 로 해결
- [x] 깔끔한 코딩
    - [x] 일급 컬렉션 사용
    - [x] record를 이용한 dto 생성
  

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new API endpoints that let users retrieve daily and weekly statistics including insights into move time, usage time, feedback, and categorized task counts.
	- Enhanced data queries, enabling more precise filtering based on user details, type, and time ranges.
- **Performance Improvements**
	- Optimized backend data loading to efficiently retrieve associated task information.
	- Streamlined aggregation of statistical data for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->