### PR TITLE
[FIX] 이동 완료시 할 일 시간처리 로직 및 피드백 시 완료한 할 일 보여주도록 수정

### DIFF
--- a/backend/src/main/java/com/dubu/backend/member/api/MemberApi.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/MemberApi.java
@@ -3,7 +3,6 @@ package com.dubu.backend.member.api;
 import com.dubu.backend.global.domain.SuccessResponse;
 import com.dubu.backend.member.dto.request.MemberInfoUpdateRequest;
 import com.dubu.backend.member.dto.request.MemberOnboardingRequest;
-import com.dubu.backend.member.dto.request.MemberStatusUpdateRequest;
 import com.dubu.backend.member.dto.response.MemberInfoResponse;
 import com.dubu.backend.member.dto.response.MemberSavedAddressResponse;
 import com.dubu.backend.member.dto.response.MemberStatusResponse;
@@ -15,7 +14,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -423,63 +423,6 @@ public interface MemberApi {
                     )
             )
             @RequestBody MemberInfoUpdateRequest request
-    );
-
-    @Operation(
-            summary = "회원 상태 변경",
-            description = """
-                    요청한 값으로 회원의 상태(Status)를 변경한다.
-                    다음 경우에 사용할 수 있습니다:
-                    1. 이동 중 페이지에서 피드백 페이지로 넘어가는 이동완료 버튼을 누를 때 회원의 상태를 MOVE에서 FEEDBACK으로 변경할 때 사용한다.
-                    """
-    )
-    @ApiResponses({
-            @ApiResponse(
-                    responseCode = "204",
-                    description = "회원 상태 업데이트 성공"
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "회원이 존재하지 않는 경우 (MEMBER_NOT_FOUND)",
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(
-                                    implementation = ErrorResponseExample.class,
-                                    description = "에러 응답 예시"
-                            ),
-                            examples = {
-                                    @ExampleObject(name = "회원 미존재 에러 예시",
-                                            value = """
-                                                    {
-                                                      "errorCode": "MEMBER_NOT_FOUND",
-                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
-                                                    }
-                                                    """)
-                            }
-                    )
-            )
-    })
-    void updateMemberStatus(
-            @Parameter(hidden = true)
-            @RequestAttribute("memberId") Long memberId,
-
-            @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                    description = "회원 상태 업데이트 요청 DTO",
-                    required = true,
-                    content = @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = MemberStatusUpdateRequest.class),
-                            examples = {
-                                    @ExampleObject(name = "회원 상태 업데이트 요청 예시",
-                                            value = """
-                                                    {
-                                                      "status": "FEEDBACK"
-                                                    }
-                                                    """)
-                            }
-                    )
-            )
-            @RequestBody MemberStatusUpdateRequest request
     );
 
     @Schema(name = "ErrorResponseExample", description = "에러 응답 예시")

--- a/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
@@ -4,7 +4,6 @@ import com.dubu.backend.global.domain.SuccessResponse;
 import com.dubu.backend.member.application.MemberService;
 import com.dubu.backend.member.dto.request.MemberInfoUpdateRequest;
 import com.dubu.backend.member.dto.request.MemberOnboardingRequest;
-import com.dubu.backend.member.dto.request.MemberStatusUpdateRequest;
 import com.dubu.backend.member.dto.response.MemberInfoResponse;
 import com.dubu.backend.member.dto.response.MemberSavedAddressResponse;
 import com.dubu.backend.member.dto.response.MemberStatusResponse;
@@ -72,14 +71,5 @@ public class MemberController implements MemberApi {
         MemberInfoResponse response = memberService.updateMemberInfo(memberId, request);
 
         return new SuccessResponse<>(response);
-    }
-
-    @ResponseStatus(NO_CONTENT)
-    @PatchMapping("/status")
-    public void updateMemberStatus(
-            @RequestAttribute("memberId") Long memberId,
-            @RequestBody MemberStatusUpdateRequest request
-    ) {
-        memberService.updateMemberStatus(memberId, request.status());
     }
 }

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
@@ -208,6 +208,7 @@ public interface PlanApi {
                                                     "endName": "역삼",
                                                     "todos": [
                                                       {
+                                                        "todoId": 99,
                                                         "isDone": true,
                                                         "title": "출근 준비",
                                                         "category": "OTHERS",

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
@@ -1,6 +1,7 @@
 package com.dubu.backend.plan.api;
 
 import com.dubu.backend.global.domain.SuccessResponse;
+import com.dubu.backend.member.api.MemberApi;
 import com.dubu.backend.plan.dto.request.PlanCreateRequest;
 import com.dubu.backend.plan.dto.request.PlanFeedbackCreateRequest;
 import com.dubu.backend.plan.dto.response.FeedbackWritePageInfoResponse;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -318,6 +320,43 @@ public interface PlanApi {
             )
     })
     SuccessResponse<FeedbackWritePageInfoResponse> getFeedbackWritePageInfo(
+            Long memberId
+    );
+
+    @Operation(
+            summary = "이동 완료 업데이트",
+            description = """
+                    이동 중 페이지에서 피드백 페이지로 넘어가는 이동완료 버튼을 누를 때 회원의 상태를 MOVE에서 FEEDBACK으로 변경할 때 사용한다. 
+                    또한 완료한 할 일들의 소모한 시간이 추가되고 TYPE 또한 DONE으로 변경된다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "이동 완료 업데이트 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원이 존재하지 않는 경우 (MEMBER_NOT_FOUND)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = MemberApi.ErrorResponseExample.class,
+                                    description = "에러 응답 예시"
+                            ),
+                            examples = {
+                                    @ExampleObject(name = "회원 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_NOT_FOUND",
+                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """)
+                            }
+                    )
+            )
+    })
+    void completePlanMove(
             Long memberId
     );
 

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanController.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanController.java
@@ -54,6 +54,14 @@ public class PlanController implements PlanApi {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/move-complete")
+    public void completePlanMove(
+            @RequestAttribute("memberId") Long memberId
+    ) {
+        planService.updateMoveStatusToFeedback(memberId);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping
     public void deletePlan(
             @RequestAttribute("memberId") Long memberId,

--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -142,13 +142,13 @@ public class PlanService {
 
         recentPlan.getPaths().forEach(path -> {
             List<Todo> todos = path.getTodos();
-            long doneCount = todos.stream().filter(Todo::isCompleted).count();
+            long doneCount = todos.stream().filter(Todo::getIsCompleted).count();
 
             if (doneCount > 0) {
                 int sectionTimePerTodo = path.getSectionTime() / todos.size();
 
                 todos.stream()
-                        .filter(Todo::isCompleted)
+                        .filter(Todo::getIsCompleted)
                         .forEach(doneTodo -> doneTodo.updateSpentTime(sectionTimePerTodo));
             }
 

--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -19,6 +19,7 @@ import com.dubu.backend.plan.infra.repository.PathRepository;
 import com.dubu.backend.plan.infra.repository.PlanRepository;
 import com.dubu.backend.todo.entity.Schedule;
 import com.dubu.backend.todo.entity.Todo;
+import com.dubu.backend.todo.entity.TodoType;
 import com.dubu.backend.todo.exception.ScheduleNotFoundException;
 import com.dubu.backend.todo.repository.ScheduleRepository;
 import com.dubu.backend.todo.repository.TodoRepository;
@@ -128,9 +129,41 @@ public class PlanService {
     }
 
     @Transactional
-    public void removePlan(Long memberId, Long planId) {
-        memberRepository.findById(memberId)
+    public void updateMoveStatusToFeedback(Long memberId) {
+        Member currentMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        if (currentMember.getStatus() != Status.MOVE) {
+            throw new InvalidMemberStatusException(currentMember.getStatus().name());
+        }
+
+        Plan recentPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
+                .orElseThrow(() -> new NotFoundPlanException());
+
+        recentPlan.getPaths().forEach(path -> {
+            List<Todo> todos = path.getTodos();
+            long doneCount = todos.stream().filter(Todo::isCompleted).count();
+
+            if (doneCount > 0) {
+                int sectionTimePerTodo = path.getSectionTime() / todos.size();
+
+                todos.stream()
+                        .filter(Todo::isCompleted)
+                        .forEach(doneTodo -> doneTodo.updateMoveDone(TodoType.DONE, sectionTimePerTodo));
+            }
+        });
+
+        currentMember.updateStatus(Status.FEEDBACK);
+    }
+
+    @Transactional
+    public void removePlan(Long memberId, Long planId) {
+        Member currentMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        if (currentMember.getStatus() != Status.MOVE) {
+            throw new InvalidMemberStatusException(currentMember.getStatus().name());
+        }
 
         Plan planToDelete = planRepository.findById(planId)
                 .orElseThrow(() -> new NotFoundPlanException(planId));

--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -149,8 +149,10 @@ public class PlanService {
 
                 todos.stream()
                         .filter(Todo::isCompleted)
-                        .forEach(doneTodo -> doneTodo.updateMoveDone(TodoType.DONE, sectionTimePerTodo));
+                        .forEach(doneTodo -> doneTodo.updateSpentTime(sectionTimePerTodo));
             }
+
+            todos.forEach(todo -> todo.updateTodoType(TodoType.DONE));
         });
 
         currentMember.updateStatus(Status.FEEDBACK);

--- a/backend/src/main/java/com/dubu/backend/plan/dto/response/FeedbackWritePageInfoResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/response/FeedbackWritePageInfoResponse.java
@@ -14,7 +14,7 @@ public record FeedbackWritePageInfoResponse(
     public static FeedbackWritePageInfoResponse of(Plan plan) {
         List<Todo> allTodos = plan.getPaths().stream()
                 .flatMap(path -> path.getTodos().stream())
-                .filter(todo -> todo.isCompleted())
+                .filter(Todo::getIsCompleted)
                 .toList();
 
         return new FeedbackWritePageInfoResponse(

--- a/backend/src/main/java/com/dubu/backend/plan/dto/response/FeedbackWritePageInfoResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/response/FeedbackWritePageInfoResponse.java
@@ -14,6 +14,7 @@ public record FeedbackWritePageInfoResponse(
     public static FeedbackWritePageInfoResponse of(Plan plan) {
         List<Todo> allTodos = plan.getPaths().stream()
                 .flatMap(path -> path.getTodos().stream())
+                .filter(todo -> todo.isCompleted())
                 .toList();
 
         return new FeedbackWritePageInfoResponse(

--- a/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
@@ -4,7 +4,6 @@ import com.dubu.backend.plan.domain.Path;
 import com.dubu.backend.plan.domain.Plan;
 import com.dubu.backend.plan.domain.enums.TrafficType;
 import com.dubu.backend.todo.entity.Todo;
-import com.dubu.backend.todo.entity.TodoType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -50,7 +49,7 @@ public record PlanRecentResponse(
 
     public record PathTodoResponse(
             Long todoId,
-            Boolean isDone,
+            boolean isDone,
             String title,
             String category,
             String difficulty,
@@ -59,7 +58,7 @@ public record PlanRecentResponse(
         public static PathTodoResponse from(Todo todo) {
             return new PathTodoResponse(
                     todo.getId(),
-                    todo.getType() == TodoType.DONE,
+                    todo.getIsCompleted() == Boolean.TRUE,
                     todo.getTitle(),
                     todo.getCategory().getName(),
                     todo.getDifficulty().name(),

--- a/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
@@ -49,6 +49,7 @@ public record PlanRecentResponse(
     }
 
     public record PathTodoResponse(
+            Long todoId,
             Boolean isDone,
             String title,
             String category,
@@ -57,6 +58,7 @@ public record PlanRecentResponse(
     ) {
         public static PathTodoResponse from(Todo todo) {
             return new PathTodoResponse(
+                    todo.getId(),
                     todo.getType() == TodoType.DONE,
                     todo.getTitle(),
                     todo.getCategory().getName(),

--- a/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
@@ -89,7 +89,8 @@ public class Todo extends BaseTimeEntity {
         this.parentTodo = null;
     }
 
-    public void updateSpentTime(int sectionTimePerTodo){
+    public void updateMoveDone(TodoType todoType, int sectionTimePerTodo){
+        this.type = todoType;
         this.spentTime = sectionTimePerTodo;
     }
 

--- a/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
@@ -27,6 +27,9 @@ public class Todo extends BaseTimeEntity {
     @Column(nullable = false)
     private TodoType type;
 
+    @Column(nullable = false, columnDefinition = "TINYINT")
+    private boolean isCompleted;
+
     @Enumerated(EnumType.ORDINAL)
     @Column(name = "difficulty", nullable = false)
     private TodoDifficulty difficulty;
@@ -37,7 +40,7 @@ public class Todo extends BaseTimeEntity {
     @Column(name = "spent_time", columnDefinition = "MEDIUMINT")
     private Integer spentTime;
 
-    @ManyToOne(fetch =  FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
@@ -84,6 +87,10 @@ public class Todo extends BaseTimeEntity {
 
     public void clearParentTodo(){
         this.parentTodo = null;
+    }
+
+    public void updateSpentTime(int sectionTimePerTodo){
+        this.spentTime = sectionTimePerTodo;
     }
 
     private void updateTitle(String title){

--- a/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
@@ -27,9 +27,6 @@ public class Todo extends BaseTimeEntity {
     @Column(nullable = false)
     private TodoType type;
 
-    @Column(nullable = false, columnDefinition = "TINYINT")
-    private boolean isCompleted;
-
     @Enumerated(EnumType.ORDINAL)
     @Column(name = "difficulty", nullable = false)
     private TodoDifficulty difficulty;

--- a/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
@@ -89,9 +89,12 @@ public class Todo extends BaseTimeEntity {
         this.parentTodo = null;
     }
 
-    public void updateMoveDone(TodoType todoType, int sectionTimePerTodo){
-        this.type = todoType;
+    public void updateSpentTime(int sectionTimePerTodo){
         this.spentTime = sectionTimePerTodo;
+    }
+
+    public void updateTodoType(TodoType todoType){
+        this.type = todoType;
     }
 
     private void updateTitle(String title){


### PR DESCRIPTION
## Issue Number
#111 

## As-Is
<!-- 문제 상황 정의 -->
이동 완료시 할 일 시간처리 로직 및 피드백 시 완료한 할 일 보여주도록 수정합니다.

## To-Be
<!-- 변경 사항 -->
- [x] 최근 계획 조회시 응답값에 todoId 추가
- [x] 경로 별 활용가능 시간에서 완료한 할 일 비율만큼 시간 처리
- [x] 피드백 정보 조회 API에서 완료한 할 일을 보여주도록 로직 변경


## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new plan completion workflow on the feedback page. When you complete your plan move, your status updates automatically while your task times are accurately tracked.

- **Bug Fixes**
  - Removed the capability to manually update member status, improving system integrity.

- **Refactor**
  - Enhanced task tracking so that feedback details now reflect only completed tasks.
  - Updated data structures to include identifiers for todo items, improving response clarity.
  - Added new methods to manage todo state, enhancing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->