### PR TITLE
[FIX] 해당경로로 출발하기 API 로직 수정

### DIFF
--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -60,7 +60,7 @@ public class PlanService {
                 .toList();
         pathRepository.saveAll(paths);
 
-        Schedule schedule = scheduleRepository.findScheduleByMemberAndDate(currentMember, LocalDate.now())
+        Schedule schedule = scheduleRepository.findLatestSchedule(currentMember, LocalDate.now())
                 .orElseThrow(() -> new ScheduleNotFoundException());
 
         List<Todo> existingTodos = schedule.getTodos();

--- a/backend/src/main/java/com/dubu/backend/todo/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/dubu/backend/todo/repository/ScheduleRepository.java
@@ -1,17 +1,8 @@
 package com.dubu.backend.todo.repository;
 
-import com.dubu.backend.member.domain.Member;
 import com.dubu.backend.todo.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
-
-import java.time.LocalDate;
-import java.util.Optional;
 
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long>, CustomScheduleRepository {
-    @Query("SELECT s FROM Schedule s WHERE s.member = :member AND s.date = :date")
-    Optional<Schedule> findScheduleByMemberAndDate(@Param("member") Member member, @Param("date") LocalDate date);
 }


### PR DESCRIPTION
## Issue Number
#120 

## As-Is
<!-- 문제 상황 정의 -->
해당경로로 춟발하기 API 로직 수정합니다.

## To-Be
<!-- 변경 사항 -->
- [x] 스케줄 조회 시 findScheduleByMemberAndDate가 아니라  findLatestSchedule로 수정
- [x] 사용하지 않는 findScheduleByMemberAndDate 메서드 삭제

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the scheduling process during plan updates so the system now consistently retrieves the most up-to-date schedule information. This change improves the accuracy and reliability of plan management, providing users with a smoother and more consistent experience when saving their plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->