### PR TITLE
[FIX] 할 일 관련 기능 수정

### DIFF
--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -14,7 +14,7 @@ import com.dubu.backend.plan.dto.request.PlanFeedbackCreateRequest;
 import com.dubu.backend.plan.dto.response.FeedbackWritePageInfoResponse;
 import com.dubu.backend.plan.dto.response.PlanRecentResponse;
 import com.dubu.backend.plan.exception.InvalidMemberStatusException;
-import com.dubu.backend.plan.exception.NotFoundPlanException;
+import com.dubu.backend.plan.exception.PlanNotFoundException;
 import com.dubu.backend.plan.exception.UnauthorizedPlanDeletionException;
 import com.dubu.backend.plan.infra.repository.FeedbackRepository;
 import com.dubu.backend.plan.infra.repository.PathRepository;
@@ -98,7 +98,7 @@ public class PlanService {
         }
 
         Plan currentPlan = planRepository.findById(planId)
-                .orElseThrow(() -> new NotFoundPlanException(planId));
+                .orElseThrow(() -> new PlanNotFoundException(planId));
 
         if (!currentPlan.getMember().getId().equals(memberId)) {
             throw new UnauthorizedPlanDeletionException(memberId, planId);
@@ -117,7 +117,7 @@ public class PlanService {
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
         Plan recentPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
-                .orElseThrow(() -> new NotFoundPlanException());
+                .orElseThrow(() -> new PlanNotFoundException());
 
         List<Path> paths = pathRepository.findByPlanWithTodosOrderByPathOrder(recentPlan);
 
@@ -134,7 +134,7 @@ public class PlanService {
         }
 
         Plan recentPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
-                .orElseThrow(() -> new NotFoundPlanException());
+                .orElseThrow(() -> new PlanNotFoundException());
 
         return FeedbackWritePageInfoResponse.of(recentPlan);
     }
@@ -149,7 +149,7 @@ public class PlanService {
         }
 
         Plan recentPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
-                .orElseThrow(() -> new NotFoundPlanException());
+                .orElseThrow(() -> new PlanNotFoundException());
 
         recentPlan.getPaths().forEach(path -> {
             List<Todo> todos = path.getTodos();
@@ -179,7 +179,7 @@ public class PlanService {
         }
 
         Plan planToDelete = planRepository.findById(planId)
-                .orElseThrow(() -> new NotFoundPlanException(planId));
+                .orElseThrow(() -> new PlanNotFoundException(planId));
 
         if (!planToDelete.getMember().getId().equals(memberId)) {
             throw new UnauthorizedPlanDeletionException(memberId, planId);

--- a/backend/src/main/java/com/dubu/backend/plan/exception/PlanNotFoundException.java
+++ b/backend/src/main/java/com/dubu/backend/plan/exception/PlanNotFoundException.java
@@ -4,12 +4,12 @@ import com.dubu.backend.global.exception.NotFoundException;
 
 import static com.dubu.backend.global.exception.ErrorCode.NOT_FOUND_PLAN;
 
-public class NotFoundPlanException extends NotFoundException {
-    public NotFoundPlanException() {
+public class PlanNotFoundException extends NotFoundException {
+    public PlanNotFoundException() {
         super(NOT_FOUND_PLAN.getMessage().formatted(""));
     }
 
-    public NotFoundPlanException(Long planId) {
+    public PlanNotFoundException(Long planId) {
         super(NOT_FOUND_PLAN.getMessage().formatted(planId));
     }
 

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PathRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PathRepository.java
@@ -12,5 +12,8 @@ public interface PathRepository extends JpaRepository<Path, Long>, CustomPathRep
     List<Path> findByPlanIdOrderByPathOrderAsc(Long id);
 
     @Query("SELECT p FROM Path p JOIN FETCH p.todos t WHERE p.plan in :plans AND t.type = :type AND t.isCompleted = :isCompleted")
-    List<Path> findByPlanAndTypeAndIsCompleted(List<Plan> plans, TodoType type, boolean isCompleted);
+    List<Path> findByPlansAndTypeAndIsCompleted(List<Plan> plans, TodoType type, boolean isCompleted);
+
+    @Query("SELECT p FROM Path p JOIN FETCH p.todos t WHERE p.plan = :plan AND t.type = :type")
+    List<Path> findByPlanAndType(Plan plan, TodoType type);
 }

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+    @Query("SELECT p FROM Plan p LEFT JOIN FETCH p.feedback WHERE p.member.id = :memberId ORDER BY p.createdAt DESC LIMIT 1")
     Optional<Plan> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
 
     @Query("SELECT p FROM Plan p JOIN FETCH p.feedback WHERE p.member = :member AND p.createdAt between :startTime AND :endTime")

--- a/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
@@ -44,7 +44,7 @@ public class StatisticServiceImpl implements StatisticService {
 
         // 쿼리 최적 -> 쿼리 분리
         List<Plan> dayPlans = planRepository.findByMemberAndCreatedAtBetween(member, date.atStartOfDay(), date.plusWeeks(1).atTime(LocalTime.MAX));
-        List<Path> dayPaths = pathRepository.findByPlanAndTypeAndIsCompleted(dayPlans, TodoType.DONE, true);
+        List<Path> dayPaths = pathRepository.findByPlansAndTypeAndIsCompleted(dayPlans, TodoType.DONE, true);
 
         if(dayPlans == null || dayPlans.isEmpty() || dayPaths == null || dayPaths.isEmpty()){
             return null;
@@ -60,7 +60,7 @@ public class StatisticServiceImpl implements StatisticService {
 
         // 쿼리 최적 -> 쿼리 분리
         List<Plan> thisWeekPlans = planRepository.findByMemberAndCreatedAtBetween(member, date.atStartOfDay(), date.plusWeeks(1).atTime(LocalTime.MAX));
-        List<Path> thisWeekPaths = pathRepository.findByPlanAndTypeAndIsCompleted(thisWeekPlans, TodoType.DONE, true);
+        List<Path> thisWeekPaths = pathRepository.findByPlansAndTypeAndIsCompleted(thisWeekPlans, TodoType.DONE, true);
 
         if(thisWeekPlans == null || thisWeekPlans.isEmpty()){
             return null;

--- a/backend/src/main/java/com/dubu/backend/todo/repository/TodoRepository.java
+++ b/backend/src/main/java/com/dubu/backend/todo/repository/TodoRepository.java
@@ -23,14 +23,20 @@ public interface TodoRepository extends JpaRepository<Todo, Long>, CustomTodoRep
     @Query("SELECT t FROM Todo t WHERE t.parentTodo = :parentTodo AND t.schedule = :schedule")
     Optional<Todo> findByParentTodoAndSchedule(@Param("parentTodo") Todo parentTodo, @Param("schedule") Schedule schedule);
 
-    @Query("SELECT t.parentTodo.id FROM Todo t WHERE t.parentTodo IN :parentTodos AND t.schedule = :schedule")
-    List<Long> findParentTodoIdsByParentTodosAndSchedule(@Param("parentTodos") List<Todo> parentTodos, @Param("schedule") Schedule schedule);
+    @Query("SELECT t.parentTodo.id FROM Todo t WHERE t.schedule = :schedule AND t.parentTodo IS NOT NULL")
+    List<Long> findParentTodoIdsByScheduleAndParentTodoNotNull(Schedule schedule);
+
+    @Query("SELECT t.parentTodo.id FROM Todo t where t.path = :path AND t.parentTodo IS NOT NULL")
+    List<Long> findParentTodoIdsByPathAndParentTodoNotNull(Path path);
 
     @Query("SELECT t.parentTodo.id FROM Todo t WHERE t.parentTodo IN :parentTodos AND t.path = :path")
     List<Long> findParentTodoIdsByParentTodosAndPath(@Param("parentTodos") List<Todo> parentTodos, @Param("path") Path path);
 
     @Query("SELECT t.parentTodo.id FROM Todo t WHERE t.parentTodo IN :parentTodos AND t.member = :member AND t.type = :type")
     List<Long> findParentTodoIdsByParentTodoAndMemberAndType(@Param("parentTodos") List<Todo> parentTodos, @Param("member") Member member, @Param("type") TodoType type);
+
+    @Query("SELECT t.parentTodo.id FROM Todo t WHERE t.id IN :ids AND t.type = :type AND t.parentTodo IS NOT NULL")
+    List<Long> findParentTodoIdsByIdsAndTypeAndParentTodoNotNull(List<Long> ids, TodoType type);
 
     @Query("SELECT t From Todo t WHERE t.member = :member AND t.parentTodo = :parentTodo AND t.type = :type")
     Optional<Todo> findByMemberAndParentTodoAndType(@Param("member") Member member, @Param("parentTodo") Todo parentTod, @Param("type") TodoType type);
@@ -46,6 +52,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long>, CustomTodoRep
 
     @Query("SELECT t FROM Todo t JOIN FETCH t.category WHERE t.schedule = :schedule")
     List<Todo> findTodosWithCategoryBySchedule(@Param("schedule")Schedule schedule);
+
 
     @Query("SELECT t FROM Todo t JOIN FETCH t.category WHERE t.path = :path")
     List<Todo> findTodosWithCategoryByPath(@Param("path") Path path);

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoQueryService.java
@@ -78,16 +78,17 @@ public class PathTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> saveTodos = todoSlice.getContent();
 
-        // 경로별 할 일 의 부모 할 일로 즐겨찾기 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfPathTodos = todoRepository.findParentTodoIdsByParentTodosAndPath(saveTodos, path);
-        HashSet<Long> parentIdOfPathTodoSet = new HashSet<>(parentIdsOfPathTodos);
+        // 경로별 할 일 의 부모 할 일이 즐겨찾기 할 일이거나 같은 부모 할 일을 가진 경우 hasChild = true
+        List<Long> pathParentTodoIds = todoRepository.findParentTodoIdsByPathAndParentTodoNotNull(path);
+
+        HashSet<Long> todayParentTodoIdSet = new HashSet<>(pathParentTodoIds);
         List<TodoInfo> todoInfos = saveTodos.stream()
-                .map(t -> {
-                    if (parentIdOfPathTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(st -> {
+                    boolean hasChild = todayParentTodoIdSet.contains(st.getId())
+                            || (st.getParentTodo() != null && todayParentTodoIdSet.contains(st.getParentTodo().getId()));
+                    return TodoInfo.fromEntity(hasChild, st);
                 }).toList();
+
 
         if(todoInfos.isEmpty()){
             return new PageResponse<>(todoSlice.hasNext(), null, todoInfos);
@@ -113,16 +114,17 @@ public class PathTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> personalizedTodos = todoRandomSelector.selectTodos(5, recommendTodos);
 
-        // 경로별 할 일 의 부모 할 일로 추천 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfPathTodos = todoRepository.findParentTodoIdsByParentTodosAndPath(personalizedTodos, path);
-        HashSet<Long> parentIdOfPathTodoSet = new HashSet<>(parentIdsOfPathTodos);
+        // 경로별 할 일 의 부모 할 일이 추천 할 일이거나 즐겨찾기 할 일인데 즐겨찾기 할 일의 부모 할 일이 추천 할 일이라면 hasChild = true
+        List<Long> pathParentTodoIds = todoRepository.findParentTodoIdsByPathAndParentTodoNotNull(path);
+        List<Long> saveParentTodoIds = todoRepository.findParentTodoIdsByIdsAndTypeAndParentTodoNotNull(pathParentTodoIds, TodoType.SAVE);
+
+        HashSet<Long> parentTodoIds = new HashSet<>(pathParentTodoIds);
+        parentTodoIds.addAll(saveParentTodoIds);
 
         return personalizedTodos.stream()
-                .map(t -> {
-                    if (parentIdOfPathTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(pt -> {
+                    boolean hasChild = parentTodoIds.contains(pt.getId());
+                    return TodoInfo.fromEntity(hasChild, pt);
                 }).toList();
     }
 
@@ -157,16 +159,17 @@ public class PathTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> recommendTodos = todoSlice.getContent();
 
-        // 경로별 할 일 의 부모 할 일로 추천 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfPathTodos = todoRepository.findParentTodoIdsByParentTodosAndPath(recommendTodos, path);
-        HashSet<Long> parentIdOfPathTodoSet = new HashSet<>(parentIdsOfPathTodos);
+        // 경로별 할 일 의 부모 할 일이 추천 할 일이거나 즐겨찾기 할 일인데 즐겨찾기 할 일의 부모 할 일이 추천 할 일이라면 hasChild = true
+        List<Long> pathParentTodoIds = todoRepository.findParentTodoIdsByPathAndParentTodoNotNull(path);
+        List<Long> saveParentTodoIds = todoRepository.findParentTodoIdsByIdsAndTypeAndParentTodoNotNull(pathParentTodoIds, TodoType.SAVE);
+
+        HashSet<Long> parentTodoIds = new HashSet<>(pathParentTodoIds);
+        parentTodoIds.addAll(saveParentTodoIds);
 
         List<TodoInfo> todoInfos = recommendTodos.stream()
-                .map(t -> {
-                    if (parentIdOfPathTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(pt -> {
+                    boolean hasChild = parentTodoIds.contains(pt.getId());
+                    return TodoInfo.fromEntity(hasChild, pt);
                 }).toList();
 
         if(todoInfos.isEmpty()){

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoManagementService.java
@@ -4,7 +4,12 @@ import com.dubu.backend.member.domain.Member;
 import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.plan.domain.Path;
+import com.dubu.backend.plan.domain.Plan;
 import com.dubu.backend.plan.exception.InvalidMemberStatusException;
+import com.dubu.backend.plan.exception.PlanNotFoundException;
+import com.dubu.backend.plan.infra.repository.PathRepository;
+import com.dubu.backend.plan.infra.repository.PlanRepository;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.request.TodoCreateFromArchivedRequest;
 import com.dubu.backend.todo.dto.request.TodoCreateRequest;
@@ -22,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,13 +37,15 @@ public class SaveTodoManagementService implements TodoManagementService {
     private final CategoryRepository categoryRepository;
     private final TodoRepository todoRepository;
     private final ScheduleRepository scheduleRepository;
+    private final PlanRepository planRepository;
+    private final PathRepository pathRepository;
 
     @Override
     public TodoManageResult<?> createTodo(TodoIdentifier identifier, TodoCreateRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        // 회원의 상태는 정지여야 한다.
-        if(!member.getStatus().equals(Status.STOP)){
+        // 회원의 상태 STOP 또는 MOVE 여야 한다.
+        if(member.getStatus().equals(Status.ONBOARDING) || member.getStatus().equals(Status.FEEDBACK)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
         Category category = categoryRepository.findByName(todoCreateRequest.category()).orElseThrow(() -> new CategoryNotFoundException(todoCreateRequest.category()));
@@ -52,8 +60,8 @@ public class SaveTodoManagementService implements TodoManagementService {
     public TodoManageResult<?> createTodoFromArchived(TodoIdentifier identifier, TodoCreateFromArchivedRequest todoCreateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        // 회원의 상태는 정지여야 한다.
-        if(!member.getStatus().equals(Status.STOP)){
+        // 회원의 상태 STOP 또는 MOVE 여야 한다.
+        if(member.getStatus().equals(Status.ONBOARDING) || member.getStatus().equals(Status.FEEDBACK)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
 
@@ -71,8 +79,8 @@ public class SaveTodoManagementService implements TodoManagementService {
     public TodoManageResult<?> modifyTodo(TodoIdentifier identifier, TodoUpdateRequest todoUpdateRequest) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        // 회원의 상태는 정지여야 한다.
-        if(!member.getStatus().equals(Status.STOP)){
+        // 회원의 상태 STOP 또는 MOVE 여야 한다.
+        if(member.getStatus().equals(Status.ONBOARDING) || member.getStatus().equals(Status.FEEDBACK)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
 
@@ -91,6 +99,19 @@ public class SaveTodoManagementService implements TodoManagementService {
             // 오늘 할 일 관련
             Schedule todaySchedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
             todoRepository.findByParentTodoAndSchedule(todo, todaySchedule).ifPresent(Todo::clearParentTodo);
+
+            // 경로별 할 일 관련
+            // 최근 계획(Plan 조회)
+            Plan latestPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(identifier.memberId()).orElseThrow(PlanNotFoundException::new);
+            List<Path> pathsOfLatestPlan = pathRepository.findByPlanAndType(latestPlan, TodoType.IN_PROGRESS);
+
+            pathsOfLatestPlan.stream()
+                    .flatMap(path -> path.getTodos().stream())
+                    .filter(pathTodo -> {
+                        Todo parentTodo = pathTodo.getParentTodo();
+                        return parentTodo != null && parentTodo.getId().equals(todo.getId());
+                    })
+                    .forEach(Todo::clearParentTodo);
 
             // 해당 할 일 관련
             todo.clearParentTodo();
@@ -116,8 +137,8 @@ public class SaveTodoManagementService implements TodoManagementService {
     public TodoManageResult<?> removeTodo(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        // 회원의 상태는 정지여야 한다.
-        if(!member.getStatus().equals(Status.STOP)){
+        // 회원의 상태 STOP 또는 MOVE 여야 한다.
+        if(member.getStatus().equals(Status.ONBOARDING) || member.getStatus().equals(Status.FEEDBACK)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
 
@@ -133,6 +154,20 @@ public class SaveTodoManagementService implements TodoManagementService {
 
         Schedule todaySchedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
         todoRepository.findByParentTodoAndSchedule(todo, todaySchedule).ifPresent(Todo::clearParentTodo);
+
+        // 즐겨찾기 할 일로부터 생성된 경로별 할 일의 부모 id 삭제
+        // 최근 계획(Plan 조회)
+        Plan latestPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(identifier.memberId()).orElseThrow(PlanNotFoundException::new);
+        List<Path> pathsOfLatestPlan = pathRepository.findByPlanAndType(latestPlan, TodoType.IN_PROGRESS);
+
+        pathsOfLatestPlan.stream()
+                .flatMap(path -> path.getTodos().stream())
+                .filter(pathTodo -> {
+                    Todo parentTodo = pathTodo.getParentTodo();
+                    return parentTodo != null && parentTodo.getId().equals(todo.getId());
+                })
+                .forEach(Todo::clearParentTodo);
+
 
         todoRepository.delete(todo);
 

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/SaveTodoQueryService.java
@@ -42,10 +42,11 @@ public class SaveTodoQueryService implements TodoQueryService {
     public PageResponse<Long, List<TodoInfo>> findSaveTodos(TodoIdentifier identifier, Long cursor, SaveTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        // 회원의 상태는 정지여야 한다.
-        if(!member.getStatus().equals(Status.STOP)){
+        // 회원의 상태 STOP 또는 MOVE 여야 한다.
+        if(member.getStatus().equals(Status.ONBOARDING) || member.getStatus().equals(Status.FEEDBACK)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
+
         Slice<Todo> todoSlice = todoRepository.findTodosUsingSingleCursor(cursor,
                 TodoSearchCond.builder()
                         .member(member)
@@ -67,8 +68,8 @@ public class SaveTodoQueryService implements TodoQueryService {
     public List<TodoInfo> findPersonalizedRecommendTodos(TodoIdentifier identifier) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        // 회원의 상태는 정지여야 한다.
-        if(!member.getStatus().equals(Status.STOP)){
+        // 회원의 상태 STOP 또는 MOVE 여야 한다.
+        if(member.getStatus().equals(Status.ONBOARDING) || member.getStatus().equals(Status.FEEDBACK)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
         // 회원의 카테고리 정보에 해당하는 추천 할 일을 가져온다.
@@ -94,8 +95,8 @@ public class SaveTodoQueryService implements TodoQueryService {
     public PageResponse<Cursor, List<TodoInfo>> findAllRecommendTodos(TodoIdentifier identifier, Cursor cursor, RecommendTodoQueryRequest request) {
         Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
 
-        // 회원의 상태는 정지여야 한다.
-        if(!member.getStatus().equals(Status.STOP)){
+        // 회원의 상태 STOP 또는 MOVE 여야 한다.
+        if(member.getStatus().equals(Status.ONBOARDING) || member.getStatus().equals(Status.FEEDBACK)){
             throw new InvalidMemberStatusException(member.getStatus().name());
         }
 

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoQueryService.java
@@ -97,15 +97,14 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> saveTodos = todoSlice.getContent();
 
-        // 오늘 할 일 의 부모 할 일로 즐겨찾기 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfTodayTodos = todoRepository.findParentTodoIdsByParentTodosAndSchedule(saveTodos, schedule);
-        HashSet<Long> parentIdOfTodayTodoSet = new HashSet<>(parentIdsOfTodayTodos);
+        // 오늘 할 일 의 부모 할 일이 즐겨찾기 할 일이거나 같은 부모 할 일을 가진 경우 hasChild = true
+        List<Long> todayParentTodoIds = todoRepository.findParentTodoIdsByScheduleAndParentTodoNotNull(schedule);
+        HashSet<Long> todayParentTodoIdSet = new HashSet<>(todayParentTodoIds);
         List<TodoInfo> todoInfos = saveTodos.stream()
-                .map(t -> {
-                    if (parentIdOfTodayTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(st -> {
+                    boolean hasChild = todayParentTodoIdSet.contains(st.getId())
+                            || (st.getParentTodo() != null && todayParentTodoIdSet.contains(st.getParentTodo().getId()));
+                    return TodoInfo.fromEntity(hasChild, st);
                 }).toList();
 
         if(todoInfos.isEmpty()){
@@ -132,16 +131,17 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> personalizedTodos = todoRandomSelector.selectTodos(5, recommendTodos);
 
-        // 오늘 할 일 의 부모 할 일로 추천 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfTodayTodos = todoRepository.findParentTodoIdsByParentTodosAndSchedule(personalizedTodos, schedule);
-        HashSet<Long> parentIdOfTodayTodoSet = new HashSet<>(parentIdsOfTodayTodos);
+        // 오늘 할 일 의 부모 할 일이 추천 할 일이거나 즐겨찾기 할 일인데 즐겨찾기 할 일의 부모 할 일이 추천 할 일이라면 hasChild = true
+        List<Long> todayParentTodoIds = todoRepository.findParentTodoIdsByScheduleAndParentTodoNotNull(schedule);
+        List<Long> saveParentTodoIds = todoRepository.findParentTodoIdsByIdsAndTypeAndParentTodoNotNull(todayParentTodoIds, TodoType.SAVE);
+
+        HashSet<Long> parentTodoIds = new HashSet<>(todayParentTodoIds);
+        parentTodoIds.addAll(saveParentTodoIds);
 
         return personalizedTodos.stream()
-                .map(t -> {
-                    if (parentIdOfTodayTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(pt -> {
+                    boolean hasChild = parentTodoIds.contains(pt.getId());
+                    return TodoInfo.fromEntity(hasChild, pt);
                 }).toList();
     }
 
@@ -176,16 +176,17 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> recommendTodos = todoSlice.getContent();
 
-        // 오늘 할 일 의 부모 할 일로 추천 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfTodayTodos = todoRepository.findParentTodoIdsByParentTodosAndSchedule(recommendTodos, schedule);
-        HashSet<Long> parentIdOfTodayTodoSet = new HashSet<>(parentIdsOfTodayTodos);
+        // 오늘 할 일 의 부모 할 일이 추천 할 일이거나 즐겨찾기 할 일인데 즐겨찾기 할 일의 부모 할 일이 추천 할 일이라면 hasChild = true
+        List<Long> todayParentTodoIds = todoRepository.findParentTodoIdsByScheduleAndParentTodoNotNull(schedule);
+        List<Long> saveParentTodoIds = todoRepository.findParentTodoIdsByIdsAndTypeAndParentTodoNotNull(todayParentTodoIds, TodoType.SAVE);
+
+        HashSet<Long> parentTodoIds = new HashSet<>(todayParentTodoIds);
+        parentTodoIds.addAll(saveParentTodoIds);
 
         List<TodoInfo> todoInfos = recommendTodos.stream()
-                .map(t -> {
-                    if (parentIdOfTodayTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(pt -> {
+                    boolean hasChild = parentTodoIds.contains(pt.getId());
+                    return TodoInfo.fromEntity(hasChild, pt);
                 }).toList();
 
         if(todoInfos.isEmpty()){

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoQueryService.java
@@ -77,15 +77,14 @@ public class TomorrowTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> saveTodos = todoSlice.getContent();
 
-        // 내일 할 일 의 부모 할 일로 즐겨찾기 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfTomorrowTodos = todoRepository.findParentTodoIdsByParentTodosAndSchedule(saveTodos, schedule);
-        HashSet<Long> parentIdOfTomorrowTodoSet = new HashSet<>(parentIdsOfTomorrowTodos);
+        // 경로별 할 일 의 부모 할 일이 즐겨찾기 할 일이거나 같은 부모 할 일을 가진 경우 hasChild = true
+        List<Long> tomorrowParentTodoIds = todoRepository.findParentTodoIdsByScheduleAndParentTodoNotNull(schedule);
+        HashSet<Long> tomorrowParentTodoIdSet = new HashSet<>(tomorrowParentTodoIds);
         List<TodoInfo> todoInfos = saveTodos.stream()
-                .map(t -> {
-                    if (parentIdOfTomorrowTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(st -> {
+                    boolean hasChild = tomorrowParentTodoIdSet.contains(st.getId())
+                            || (st.getParentTodo() != null && tomorrowParentTodoIdSet.contains(st.getParentTodo().getId()));
+                    return TodoInfo.fromEntity(hasChild, st);
                 }).toList();
 
         if(todoInfos.isEmpty()){
@@ -112,16 +111,17 @@ public class TomorrowTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> personalizedTodos = todoRandomSelector.selectTodos(5, recommendTodos);
 
-        // 내일 할 일 의 부모 할 일로 추천 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfTomorrowTodos = todoRepository.findParentTodoIdsByParentTodosAndSchedule(personalizedTodos, schedule);
-        HashSet<Long> parentIdOfTomorrowTodoSet = new HashSet<>(parentIdsOfTomorrowTodos);
+        // 내일 할 일 의 부모 할 일이 추천 할 일이거나 즐겨찾기 할 일인데 즐겨찾기 할 일의 부모 할 일이 추천 할 일이라면 hasChild = true
+        List<Long> tomorrowParentTodoIds = todoRepository.findParentTodoIdsByScheduleAndParentTodoNotNull(schedule);
+        List<Long> saveParentTodoIds = todoRepository.findParentTodoIdsByIdsAndTypeAndParentTodoNotNull(tomorrowParentTodoIds, TodoType.SAVE);
+
+        HashSet<Long> parentTodoIds = new HashSet<>(tomorrowParentTodoIds);
+        parentTodoIds.addAll(saveParentTodoIds);
 
         return personalizedTodos.stream()
-                .map(t -> {
-                    if (parentIdOfTomorrowTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(pt -> {
+                    boolean hasChild = parentTodoIds.contains(pt.getId());
+                    return TodoInfo.fromEntity(hasChild, pt);
                 }).toList();
     }
 
@@ -156,16 +156,17 @@ public class TomorrowTodoQueryService implements TargetTodoQueryService {
 
         List<Todo> recommendTodos = todoSlice.getContent();
 
-        // 내일 할 일 의 부모 할 일로 추천 할 일이 있는지를 확인하고 있으면 hasChild = true, 없으면 hasChild = false 설정
-        List<Long> parentIdsOfTomorrowTodos = todoRepository.findParentTodoIdsByParentTodosAndSchedule(recommendTodos, schedule);
-        HashSet<Long> parentIdOfTomorrowTodoSet = new HashSet<>(parentIdsOfTomorrowTodos);
+        // 내일 할 일 의 부모 할 일이 추천 할 일이거나 즐겨찾기 할 일인데 즐겨찾기 할 일의 부모 할 일이 추천 할 일이라면 hasChild = true
+        List<Long> tomorrowParentTodoIds = todoRepository.findParentTodoIdsByScheduleAndParentTodoNotNull(schedule);
+        List<Long> saveParentTodoIds = todoRepository.findParentTodoIdsByIdsAndTypeAndParentTodoNotNull(tomorrowParentTodoIds, TodoType.SAVE);
+
+        HashSet<Long> parentTodoIds = new HashSet<>(tomorrowParentTodoIds);
+        parentTodoIds.addAll(saveParentTodoIds);
 
         List<TodoInfo> todoInfos = recommendTodos.stream()
-                .map(t -> {
-                    if (parentIdOfTomorrowTodoSet.contains(t.getId())) {
-                        return TodoInfo.fromEntity(true, t);
-                    }
-                    return TodoInfo.fromEntity(false, t);
+                .map(pt -> {
+                    boolean hasChild = parentTodoIds.contains(pt.getId());
+                    return TodoInfo.fromEntity(hasChild, pt);
                 }).toList();
 
         if(todoInfos.isEmpty()){


### PR DESCRIPTION
## Issue Number

close #155 
## As-Is
<!-- 문제 상황 정의 -->
경로별 할 일과 마이 페이지 즐겨찾기 할 일 기능 수정
즐겨찾기/추천 할 일 리스트 조회 관련 hasChild 값이 true 되는 로직 변경

## To-Be
<!-- 변경 사항 -->
- [x] 경로별 할 일과 마이 페이지 즐겨찾기 할 일 기능 수정
    - [x] Plan 과 Feedback 에 대한 N + 1 문제 해결
    - [x] 마이 페이지 즐겨찾기 할 일 수정 혹은 삭제 시 해당 할 일을 부모 할 일로 하는 경로별 할 일 부모 할 일 제거
- [x] 즐겨찾기/추천 할 일 리스트 조회 관련 hasChild 값이 true 되는 로직 변경
    - [x] 즐겨찾기 할 일 리스트 조회 시 오늘/내일/경로별 할 일의 부모 할 일이 즐겨찾기 할 일과 동일하면 hasChild = true
    - [x] 추천 할 일 조회 시 오늘/내일/경로별 할 일의 부모 할 일(즐겨찾기 할 일)의 부모 할 일이 추천 할 일과 동일하면 hasChild = true 

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to retrieve the most recent plan created by users.
  - Expanded query capabilities to better manage hierarchical task relationships.

- **Refactor**
  - Enhanced error reporting for scenarios where plans are missing, providing clearer feedback.
  - Revised account validation to support additional user statuses.
  - Optimized logic for determining task relationships across personalized and scheduled views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->