### PR TITLE
[REFACTOR] BottomSheet Context로 관리하여 사용성 개선하기

### DIFF
--- a/frontend/src/hooks/useOverlay.ts
+++ b/frontend/src/hooks/useOverlay.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+
+import { OverlayContext } from '@/providers/OverlayProvider';
+
+const useOverlay = () => {
+  const dispatch = useContext(OverlayContext);
+
+  if (!dispatch) {
+    throw new Error('OverlayContext가 존재하지 않습니다.');
+  }
+
+  return dispatch;
+};
+
+export default useOverlay;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { RouterProvider } from 'react-router';
 import { ThemeProvider } from 'styled-components';
 
 import ToastProvider from './components/Toast/ToastProvider';
+import { OverlayProvider } from './providers/OverlayProvider';
 import { router } from './router';
 import GlobalStyle from './styles/GlobalStyle.js';
 import theme from './styles/theme';
@@ -27,7 +28,9 @@ enableMocking().then(() => {
       <ThemeProvider theme={theme}>
         <GlobalStyle />
         <ToastProvider>
-          <RouterProvider router={router} />
+          <OverlayProvider>
+            <RouterProvider router={router} />
+          </OverlayProvider>
         </ToastProvider>
         <ReactQueryDevtools initialIsOpen={false} />
       </ThemeProvider>

--- a/frontend/src/pages/EditPage/components/FavoriteTab/index.tsx
+++ b/frontend/src/pages/EditPage/components/FavoriteTab/index.tsx
@@ -1,12 +1,11 @@
 import * as S from './FavoriteTab.styled';
-import { useAddTodoBottomSheet } from '../../hooks/useAddTodoBottomSheet';
+import useAddTodoBottomSheet from '../../hooks/useAddTodoBottomSheet';
 import useAddTodoFromArchivedMutation from '../../hooks/useAddTodoFromArchivedMutation';
 import useDeleteTodoMutation from '../../hooks/useDeleteTodoMutation';
 import useEditTodoBottomSheet from '../../hooks/useEditTodoBottomSheet';
 import useFavoriteTodoListQuery from '../../hooks/useFavoriteListQuery';
 import TodoEditItem from '../TodoEditItem';
 
-import BottomSheet from '@/components/BottomSheet';
 import IconButton from '@/components/Button/IconButton';
 import Icon from '@/components/Icon';
 import { MAX_TODO_ITEM_LENGTH, TODO_TYPE } from '@/constants/config';
@@ -30,21 +29,8 @@ const FavoriteTab = ({ todoType, planId }: FavoriteTabProps) => {
   const { mutate: deleteTodo } = useDeleteTodoMutation(todoType);
 
   const { toast } = useToast();
-  const {
-    isOpen: isAddOpen,
-    open: openAddBottomSheet,
-    close: closeAddBottomSheet,
-    content: addContent,
-    title: addTodoForm,
-  } = useAddTodoBottomSheet(todoType, planId);
-
-  const {
-    isOpen: isEditOpen,
-    open: openEditBottomSheet,
-    close: closeEditBottomSheet,
-    content: editTodoForm,
-    title: editTitle,
-  } = useEditTodoBottomSheet(todoType, planId);
+  const openAddBottomSheet = useAddTodoBottomSheet({ todoType, planId });
+  const openEditBottomSheet = useEditTodoBottomSheet({ todoType, planId });
 
   const isFavoritePage = todoType === TODO_TYPE.SAVE;
 
@@ -125,18 +111,6 @@ const FavoriteTab = ({ todoType, planId }: FavoriteTabProps) => {
           />
         )}
       </S.FavoriteTabLayout>
-      <BottomSheet
-        isOpen={isAddOpen}
-        title={addTodoForm}
-        content={addContent}
-        onClose={closeAddBottomSheet}
-      />
-      <BottomSheet
-        isOpen={isEditOpen}
-        title={editTitle}
-        content={editTodoForm}
-        onClose={closeEditBottomSheet}
-      />
     </>
   );
 };

--- a/frontend/src/pages/EditPage/components/TodoTab/index.tsx
+++ b/frontend/src/pages/EditPage/components/TodoTab/index.tsx
@@ -1,11 +1,10 @@
 import TodoEditItem from '../TodoEditItem';
 import * as S from './TodoTab.styled';
 import { TODO_TAB_TEXT } from '../../EditPage.constants';
-import { useAddTodoBottomSheet } from '../../hooks/useAddTodoBottomSheet';
+import useAddTodoBottomSheet from '../../hooks/useAddTodoBottomSheet';
 import useDeleteTodoMutation from '../../hooks/useDeleteTodoMutation';
 import useEditTodoBottomSheet from '../../hooks/useEditTodoBottomSheet';
 
-import BottomSheet from '@/components/BottomSheet';
 import IconButton from '@/components/Button/IconButton';
 import Icon from '@/components/Icon';
 import { MAX_TODO_ITEM_LENGTH, TODO_TYPE } from '@/constants/config';
@@ -24,28 +23,15 @@ interface TodoTabProps {
 const TodoTab = ({ todoType, planId }: TodoTabProps) => {
   const { dateType } = useQueryParamsDate();
 
-  const { toast } = useToast();
   const { data: currentTodoList } = useTodoListQuery(dateType, Number(planId));
   const { data: routeTodoList } = useRouteTodoQuery(Number(planId));
   const { mutate: deleteTodo } = useDeleteTodoMutation(todoType);
 
   const todoList = currentTodoList || routeTodoList;
 
-  const {
-    isOpen: isAddOpen,
-    open: openAddBottomSheet,
-    close: closeAddBottomSheet,
-    content: addContent,
-    title: addTodoForm,
-  } = useAddTodoBottomSheet(todoType, planId);
-
-  const {
-    isOpen: isEditOpen,
-    open: openEditBottomSheet,
-    close: closeEditBottomSheet,
-    content: editTodoForm,
-    title: editTitle,
-  } = useEditTodoBottomSheet(todoType, planId);
+  const { toast } = useToast();
+  const openAddTodoBottomSheet = useAddTodoBottomSheet({ todoType, planId });
+  const openEditBottomSheet = useEditTodoBottomSheet({ todoType, planId });
 
   const handleClickAddTodo = () => {
     const isLimitType = todoType === TODO_TYPE.TODAY || todoType === TODO_TYPE.TOMORROW;
@@ -56,7 +42,7 @@ const TodoTab = ({ todoType, planId }: TodoTabProps) => {
       return;
     }
 
-    openAddBottomSheet();
+    openAddTodoBottomSheet();
   };
 
   const handleDeleteTodo = (todoId: number) => {
@@ -97,19 +83,6 @@ const TodoTab = ({ todoType, planId }: TodoTabProps) => {
           onClick={handleClickAddTodo}
         />
       </S.TodoEditList>
-
-      <BottomSheet
-        isOpen={isAddOpen}
-        title={addTodoForm}
-        content={addContent}
-        onClose={closeAddBottomSheet}
-      />
-      <BottomSheet
-        isOpen={isEditOpen}
-        title={editTitle}
-        content={editTodoForm}
-        onClose={closeEditBottomSheet}
-      />
     </S.TodoTabLayout>
   );
 };

--- a/frontend/src/pages/EditPage/hooks/useAddTodoBottomSheet.tsx
+++ b/frontend/src/pages/EditPage/hooks/useAddTodoBottomSheet.tsx
@@ -3,12 +3,17 @@ import TodoAddForm from '../components/TodoTab/TodoAddForm';
 
 import { TodoCreateParams } from '@/api/todo';
 import { TODO_TOAST_MESSAGE } from '@/constants/message';
-import useBaseBottomSheet from '@/hooks/useBaseBottomSheet';
+import useOverlay from '@/hooks/useOverlay';
 import useToast from '@/hooks/useToast';
 import { TodoType } from '@/types/todo';
 
-export const useAddTodoBottomSheet = (todoType: TodoType, planId?: number) => {
-  const { isOpen, dispatch } = useBaseBottomSheet();
+interface UseAddTodoBottomSheetProps {
+  todoType: TodoType;
+  planId?: number;
+}
+
+const useAddTodoBottomSheet = ({ todoType, planId }: UseAddTodoBottomSheetProps) => {
+  const overlay = useOverlay();
   const { mutate: addTodo, isPending } = useAddTodoMutation();
   const { toast } = useToast();
 
@@ -18,18 +23,19 @@ export const useAddTodoBottomSheet = (todoType: TodoType, planId?: number) => {
       {
         onSuccess: () => {
           toast({ message: TODO_TOAST_MESSAGE.add });
-          dispatch.close();
+          overlay.close();
         },
       },
     );
   };
 
-  return {
-    isOpen,
-    open: dispatch.open,
-    close: dispatch.close,
-    handleAddTodo,
-    content: <TodoAddForm handleAddTodo={handleAddTodo} isLoading={isPending} />,
-    title: '할 일 추가하기',
+  const openAddTodoBottomSheet = () => {
+    overlay.open(() => <TodoAddForm handleAddTodo={handleAddTodo} isLoading={isPending} />, {
+      title: '할 일 추가하기',
+    });
   };
+
+  return openAddTodoBottomSheet;
 };
+
+export default useAddTodoBottomSheet;

--- a/frontend/src/pages/EditPage/hooks/useEditTodoBottomSheet.tsx
+++ b/frontend/src/pages/EditPage/hooks/useEditTodoBottomSheet.tsx
@@ -1,40 +1,36 @@
-import { useState } from 'react';
-
 import useEditTodoMutation from './useEditTodoMutation';
 import TodoEditForm from '../components/TodoEditForm';
 
-import useBaseBottomSheet from '@/hooks/useBaseBottomSheet';
+import useOverlay from '@/hooks/useOverlay';
 import { Todo, TodoType } from '@/types/todo';
 
-const useEditTodoBottomSheet = (todoType: TodoType, planId?: number) => {
-  const { isOpen, dispatch } = useBaseBottomSheet();
-  const [selectedTodo, setSelectedTodo] = useState<Todo | null>(null);
-  const { mutate: editTodo } = useEditTodoMutation(todoType);
+interface UseAddBottomSheetProps {
+  todoType: TodoType;
+  planId?: number;
+}
 
-  const handleOpen = (todo: Todo) => {
-    setSelectedTodo(todo);
-    dispatch.open();
-  };
+const useEditBottomSheet = ({ todoType, planId }: UseAddBottomSheetProps) => {
+  const { mutate: editTodo } = useEditTodoMutation(todoType);
+  const overlay = useOverlay();
 
   const handleEditTodo = (todo: Todo) => {
     editTodo(
       { todo, planId },
       {
         onSuccess: () => {
-          dispatch.close();
+          overlay.close();
         },
       },
     );
   };
 
-  return {
-    isOpen,
-    open: handleOpen,
-    close: dispatch.close,
-    handleEditTodo,
-    content: selectedTodo && <TodoEditForm todo={selectedTodo} handleEditTodo={handleEditTodo} />,
-    title: '할 일 수정하기',
+  const openEditTodoBottomSheet = (todo: Todo) => {
+    overlay.open(() => <TodoEditForm handleEditTodo={handleEditTodo} todo={todo} />, {
+      title: '할 일 수정하기',
+    });
   };
+
+  return openEditTodoBottomSheet;
 };
 
-export default useEditTodoBottomSheet;
+export default useEditBottomSheet;

--- a/frontend/src/pages/MapPage/hooks/useMarkerBottomSheet.tsx
+++ b/frontend/src/pages/MapPage/hooks/useMarkerBottomSheet.tsx
@@ -1,31 +1,15 @@
-import { useState } from 'react';
-
 import DetailUserTodo from '../components/DetailTodo';
 
-import useBaseBottomSheet from '@/hooks/useBaseBottomSheet';
+import useOverlay from '@/hooks/useOverlay';
 
 const useMarkerBottomSheet = () => {
-  const {
-    isOpen,
-    dispatch: { open, close },
-  } = useBaseBottomSheet();
-  const [selectedMemberId, setSelectedMemberId] = useState<number | null>(null);
+  const overlay = useOverlay();
 
-  const handleOpen = (memberId: number) => {
-    setSelectedMemberId(memberId);
-    open();
+  const openMarkerBottomSheet = (memberId: number) => {
+    overlay.open(() => <DetailUserTodo memberId={memberId} />);
   };
 
-  const handleClose = () => {
-    setSelectedMemberId(null);
-    close();
-  };
-
-  return {
-    isOpen,
-    open: handleOpen,
-    close: handleClose,
-    content: selectedMemberId !== null && <DetailUserTodo memberId={selectedMemberId} />,
-  };
+  return openMarkerBottomSheet;
 };
+
 export default useMarkerBottomSheet;

--- a/frontend/src/pages/MapPage/index.tsx
+++ b/frontend/src/pages/MapPage/index.tsx
@@ -19,14 +19,8 @@ const MapPage = () => {
   const { putMarkerList } = useMarker();
   const { categoryFilters, handleCheckFilters } = useCategoryFilters();
   const { isOpen, close } = useMapBottomSheet();
+  const openMarkerBottomSheet = useMarkerBottomSheet();
   const { data: nearbyUsersData } = useNearbyUsersQuery({ lng: center.lng, lat: center.lat });
-
-  const {
-    isOpen: isMarkerBottomSheetOpen,
-    open: openMarkerBottomSheet,
-    close: closeMarkerBottomSheet,
-    content: markerBottomSheetContent,
-  } = useMarkerBottomSheet();
 
   putMarkerList(mapRef.current, openMarkerBottomSheet, nearbyUsersData?.nearMember);
 
@@ -67,12 +61,6 @@ const MapPage = () => {
         onClose={close}
         content={<CategoryRank lng={center.lng} lat={center.lat} />}
         subTitle="반경 3km 이내"
-      />
-
-      <BottomSheet
-        isOpen={isMarkerBottomSheetOpen}
-        onClose={closeMarkerBottomSheet}
-        content={markerBottomSheetContent}
       />
 
       {/* 현재 위치로 이동 버튼 */}

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
@@ -1,11 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
-import React, { useEffect, useReducer, useRef, useState } from 'react';
+import { useEffect, useReducer, useRef, useState } from 'react';
 
 import * as S from './TimeBlockItem.styled';
-import TodoShowForm from './TodoShowForm';
 
 import { checkTodo, PathTodo } from '@/api/plan';
-import BottomSheet from '@/components/BottomSheet';
 import Icon from '@/components/Icon';
 import { ICON_MAPPER } from '@/constants/config';
 import useShowTodoBottomSheet from '@/pages/PlanPage/hooks/useShowTodoBottomSheet';
@@ -24,7 +22,7 @@ interface TimeBlockItemProps {
 }
 
 const TimeBlockItem = ({ todo }: TimeBlockItemProps) => {
-  const { isOpen, open, close, title } = useShowTodoBottomSheet();
+  const showTodoBottomSheet = useShowTodoBottomSheet();
   const { mutateAsync: checkTodo } = useCheckTodoMutation();
 
   const [isDone, toggle] = useReducer((prev) => !prev, todo.isDone);
@@ -65,17 +63,11 @@ const TimeBlockItem = ({ todo }: TimeBlockItemProps) => {
           <Icon icon="FilledCheck" cursor="pointer" />
           <Icon icon={ICON_MAPPER[todo.category]} cursor="pointer" />
         </S.CheckIconWrapper>
-        <S.TimeBlockContent onClick={open}>
+        <S.TimeBlockContent onClick={() => showTodoBottomSheet(todo)}>
           <S.TodoTitle $isDone={isDone}>{todo.title}</S.TodoTitle>
           <S.TodoMemo>{todo.memo}</S.TodoMemo>
         </S.TimeBlockContent>
       </S.TimeBlockItem>
-      <BottomSheet
-        isOpen={isOpen}
-        onClose={close}
-        title={title}
-        content={<TodoShowForm todo={todo} />}
-      />
     </>
   );
 };

--- a/frontend/src/pages/PlanPage/hooks/useShowTodoBottomSheet.tsx
+++ b/frontend/src/pages/PlanPage/hooks/useShowTodoBottomSheet.tsx
@@ -1,14 +1,16 @@
-import useBaseBottomSheet from '@/hooks/useBaseBottomSheet';
+import TodoShowForm from '../components/TimeBlockContent/TimeBlockList/TimeBlockItem/TodoShowForm';
+
+import useOverlay from '@/hooks/useOverlay';
+import { Todo } from '@/types/todo';
 
 const useShowTodoBottomSheet = () => {
-  const { isOpen, dispatch } = useBaseBottomSheet();
+  const overlay = useOverlay();
 
-  return {
-    isOpen,
-    open: dispatch.open,
-    close: dispatch.close,
-    title: '할 일 보기',
+  const showTodoBottomSheet = (todo: Todo) => {
+    overlay.open(() => <TodoShowForm todo={todo} />, { title: '할 일 보기' });
   };
+
+  return showTodoBottomSheet;
 };
 
 export default useShowTodoBottomSheet;

--- a/frontend/src/pages/RecommendTodoPage/components/RecommendTodoContainer/index.tsx
+++ b/frontend/src/pages/RecommendTodoPage/components/RecommendTodoContainer/index.tsx
@@ -6,9 +6,7 @@ import useFilterBottomSheet from '../../hooks/useFilterBottomSheet';
 import useMemberInfoQuery from '../../hooks/useMemberInfoQuery';
 import useRecommendTodoFilterQuery from '../../hooks/useRecommendTodoFilterQuery';
 import { getTodoType } from '../../RecommendTodoPage.utils';
-import FilterForm from '../FilterForm';
 
-import BottomSheet from '@/components/BottomSheet';
 import IconButton from '@/components/Button/IconButton';
 import Icon from '@/components/Icon';
 import { MAX_TODO_ITEM_LENGTH, TODO_TYPE } from '@/constants/config';
@@ -27,7 +25,7 @@ interface RecommendTodoContainerProps {
 const RecommendTodoContainer = ({ isFavoritePage }: RecommendTodoContainerProps) => {
   const { planId } = useParams();
   const { dateType } = useQueryParamsDate();
-  const { isOpen, open, close } = useFilterBottomSheet();
+  const openFilterBottomSheet = useFilterBottomSheet();
 
   const [categoryList, setCategoryList] = useState<CategoryType[]>([]);
   const [difficultyList, setDifficultyList] = useState<DifficultyType[]>([]);
@@ -95,7 +93,11 @@ const RecommendTodoContainer = ({ isFavoritePage }: RecommendTodoContainerProps)
 
   return (
     <>
-      <S.FilterWrapper onClick={open}>
+      <S.FilterWrapper
+        onClick={() =>
+          openFilterBottomSheet({ categoryList, difficultyList, onConfirm: handleFilter })
+        }
+      >
         <S.IconButtonWrapper
           $isSelected={isCategory}
           flex="row-reverse"
@@ -132,18 +134,6 @@ const RecommendTodoContainer = ({ isFavoritePage }: RecommendTodoContainerProps)
           />
         ))}
       </S.RecommendTabList>
-      <BottomSheet
-        isOpen={isOpen}
-        onClose={close}
-        content={
-          <FilterForm
-            selectedCategoryList={categoryList}
-            selectedDifficultyList={difficultyList}
-            onClose={close}
-            onConfirm={handleFilter}
-          />
-        }
-      />
     </>
   );
 };

--- a/frontend/src/pages/RecommendTodoPage/hooks/useFilterBottomSheet.tsx
+++ b/frontend/src/pages/RecommendTodoPage/hooks/useFilterBottomSheet.tsx
@@ -1,13 +1,33 @@
-import useBaseBottomSheet from '@/hooks/useBaseBottomSheet';
+import FilterForm from '../components/FilterForm';
+
+import useOverlay from '@/hooks/useOverlay';
+import { CategoryType, DifficultyType } from '@/types/filter';
+
+export interface OpenFilterBottomSheetParams {
+  categoryList: CategoryType[];
+  difficultyList: DifficultyType[];
+  onConfirm: (categoryList: CategoryType[], difficultyList: DifficultyType[]) => void;
+}
 
 const useFilterBottomSheet = () => {
-  const { isOpen, dispatch } = useBaseBottomSheet();
+  const overlay = useOverlay();
 
-  return {
-    isOpen,
-    open: dispatch.open,
-    close: dispatch.close,
+  const openFilterBottomSheet = ({
+    categoryList,
+    difficultyList,
+    onConfirm,
+  }: OpenFilterBottomSheetParams) => {
+    overlay.open(() => (
+      <FilterForm
+        selectedCategoryList={categoryList}
+        selectedDifficultyList={difficultyList}
+        onClose={overlay.close}
+        onConfirm={onConfirm}
+      />
+    ));
   };
+
+  return openFilterBottomSheet;
 };
 
 export default useFilterBottomSheet;

--- a/frontend/src/providers/OverlayProvider.tsx
+++ b/frontend/src/providers/OverlayProvider.tsx
@@ -1,0 +1,65 @@
+import { createContext, PropsWithChildren, useCallback, useMemo, useState } from 'react';
+
+import BottomSheet from '@/components/BottomSheet';
+
+interface OverlayProps {
+  title?: string;
+  subTitle?: string;
+}
+
+interface Overlay extends OverlayProps {
+  Component: React.FC<OverlayState> | null;
+  isOpen: boolean;
+}
+
+interface OverlayState {
+  isOpen: boolean;
+}
+
+interface OverlayContextProps {
+  open: (Component: React.FC<OverlayState> | null, props?: OverlayProps) => void;
+  close: () => void;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const OverlayContext = createContext<OverlayContextProps | null>(null);
+
+export const OverlayProvider = ({ children }: PropsWithChildren) => {
+  const [overlay, setOverlay] = useState<Overlay>({
+    Component: null,
+    isOpen: false,
+  });
+
+  const open = useCallback((Component: React.FC<OverlayState> | null, props?: OverlayProps) => {
+    setOverlay({
+      ...props,
+      Component,
+      isOpen: true,
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    setOverlay((prev) => ({
+      ...prev,
+      Component: null,
+      isOpen: false,
+    }));
+  }, []);
+
+  const dispatch = useMemo(() => ({ open, close }), [open, close]);
+
+  return (
+    <OverlayContext.Provider value={dispatch}>
+      {children}
+      {overlay.isOpen && overlay.Component && (
+        <BottomSheet
+          isOpen={overlay.isOpen}
+          onClose={close}
+          title={overlay.title}
+          subTitle={overlay.subTitle}
+          content={<overlay.Component {...overlay} />}
+        />
+      )}
+    </OverlayContext.Provider>
+  );
+};


### PR DESCRIPTION
## Issue Number
close #151 

## As-Is
<!-- 문제 상황 정의 -->
- 바텀시트를 매번 선언해줘야하고, 컴포넌트의 JSX에 바텀시트가 위치하여 컴포넌트를 복잡하게 만들고, 컴포넌트의 역할을 늘린다.

## To-Be
<!-- 변경 사항 -->
- 바텀시트를 context로 관리하면서 UI 역할을 OverlayProvider에게 위임하여 바텀시트의 사용성을 높인다.

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

사용하는 컴포넌트 측에선 BottomSheet는 참조하지 않고, 바텀 시트에 보여줄 UI와 데이터만 넣어줍니다. 기존의 BottomSheet 자체가 컴포넌트단에 import되서 역할이 많아졌다면, BottomSheet 컴포넌트는 도메인 컴포넌트에서 분리시켰습니다.

다만, 예외적으로 바텀시트가 페이지 들어오자마자 떠야하는 지도의 카테고리 랭킹같은 경우 사용하기 어려웠습니다. isOpen 상태값을 Provider가 관리하고 있어 true값으로 시작할 수 없고, useEffect로 open() 한다면 좌표값에 따라 바텀시트 내의 컴포넌트에 들어가는 데이터가 달라져야하는데, 이럴 경우 바텀시트가 여러개뜨는 문제가 있어 제거하였습니다. 추후, toss slash의 useOverlay처럼 isOpen값을 첫번째 인자로 받도록 하여 처리할 수도 있을 것 같습니다!

https://www.slash.page/ko/libraries/react/use-overlay/src/useOverlay.i18n

### ❌ before

```tsx
  const {
    isOpen: isAddOpen,
    open: openAddBottomSheet,
    close: closeAddBottomSheet,
    content: addContent,
    title: addTodoForm,
  } = useAddTodoBottomSheet(todoType, planId);

  const {
    isOpen: isEditOpen,
    open: openEditBottomSheet,
    close: closeEditBottomSheet,
    content: editTodoForm,
    title: editTitle,
  } = useEditTodoBottomSheet(todoType, planId);

  return (
    ...

      <BottomSheet
        isOpen={isAddOpen}
        title={addTodoForm}
        content={addContent}
        onClose={closeAddBottomSheet}
      />
      <BottomSheet
        isOpen={isEditOpen}
        title={editTitle}
        content={editTodoForm}
        onClose={closeEditBottomSheet}
      />

  )
}
```

### ✅ after 

```tsx
  const openAddTodoBottomSheet = useAddTodoBottomSheet({ todoType, planId });
  const openEditBottomSheet = useEditTodoBottomSheet({ todoType, planId });

  const handleClickAddTodo = () => {
    ...

    openAddTodoBottomSheet();
  };
```
