### PR TITLE
[FIX] 알림 구독 저장 시 중복 로직 추가

### DIFF
--- a/backend/src/main/java/com/dubu/backend/global/exception/ConflictException.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/ConflictException.java
@@ -1,7 +1,7 @@
 package com.dubu.backend.global.exception;
 
-public abstract class BadRequestException extends RuntimeException {
-    public BadRequestException(String message) {
+public abstract class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
         super(message);
     }
 

--- a/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
@@ -42,6 +42,9 @@ public enum ErrorCode {
     // Address
     MEMBER_SAVED_ADDRESS_NOT_FOUND(NOT_FOUND, "회원이 저장한 주소를 찾을 수 없습니다. memberId : %d"),
 
+    // Subscription
+    DUPLICATE_SUBSCRIPTION(CONFLICT, "이미 알림을 구독한 브라우저입니다."),
+
     // Category
     CATEGORY_NOT_FOUND(NOT_FOUND, "카테고리를 찾을 수 없습니다. categoryName : %s"),
 

--- a/backend/src/main/java/com/dubu/backend/global/exception/InternalServerException.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/InternalServerException.java
@@ -1,7 +1,6 @@
 package com.dubu.backend.global.exception;
 
 public abstract class InternalServerException extends RuntimeException {
-
   public InternalServerException(String message) {
     super(message);
   }

--- a/backend/src/main/java/com/dubu/backend/global/exception/NotFoundException.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/NotFoundException.java
@@ -1,7 +1,6 @@
 package com.dubu.backend.global.exception;
 
 public abstract class NotFoundException extends RuntimeException {
-
     public NotFoundException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/dubu/backend/global/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/UnauthorizedException.java
@@ -1,7 +1,6 @@
 package com.dubu.backend.global.exception;
 
 public abstract class UnauthorizedException extends RuntimeException {
-
     public UnauthorizedException(String message) {
         super(message);
     }

--- a/backend/src/main/java/com/dubu/backend/notification/api/NotificationApi.java
+++ b/backend/src/main/java/com/dubu/backend/notification/api/NotificationApi.java
@@ -45,18 +45,18 @@ public interface NotificationApi {
                     )
             ),
             @ApiResponse(
-                    responseCode = "503",
-                    description = "푸시 서비스 문제로 인해 구독 정보를 등록할 수 없는 경우 (UNAVAILABLE_PUSH_SERVICE)",
+                    responseCode = "409",
+                    description = "이미 해당 브라우저에서 푸시 구독이 완료된 경우 (DUPLICATE_SUBSCRIPTION)",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = ErrorResponseExample.class),
                             examples = {
                                     @ExampleObject(
-                                            name = "푸시 서비스 장애 에러 예시",
+                                            name = "중복 구독 에러 예시",
                                             value = """
                                                     {
-                                                      "errorCode": "UNAVAILABLE_PUSH_SERVICE",
-                                                      "message": "현재 푸시 서비스를 이용할 수 없습니다."
+                                                      "errorCode": "DUPLICATE_SUBSCRIPTION",
+                                                      "message": "이미 알림을 구독한 브라우저입니다."
                                                     }
                                                     """
                                     )

--- a/backend/src/main/java/com/dubu/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/dubu/backend/notification/application/NotificationService.java
@@ -8,6 +8,7 @@ import com.dubu.backend.notification.config.VapidKeyConfig;
 import com.dubu.backend.notification.domain.PushSubscription;
 import com.dubu.backend.notification.dto.PushMessageDto;
 import com.dubu.backend.notification.dto.PushSubscriptionDto;
+import com.dubu.backend.notification.exception.DuplicateSubscriptionException;
 import com.dubu.backend.notification.exception.UnavailablePushServiceException;
 import com.dubu.backend.notification.infra.repository.PushSubscriptionRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import nl.martijndwars.webpush.Notification;
 import nl.martijndwars.webpush.PushService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,18 +37,17 @@ public class NotificationService {
 
     @Transactional
     public void saveSubscription(Long memberId, PushSubscriptionDto subscriptionDto) {
-        Member member = memberRepository.findById(memberId)
+        Member currentMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
-        PushSubscription pushSubscription = PushSubscription.builder()
-                .member(member)
-                .endPoint(subscriptionDto.endpoint())
-                .p256dh(subscriptionDto.keys().p256dh())
-                .auth(subscriptionDto.keys().auth())
-                .build();
+        PushSubscription pushSubscription = PushSubscription.createSubscription(currentMember, subscriptionDto);
 
-        subscriptionRepository.save(pushSubscription);
-        log.info("[구독 저장] memberId={}, endpoint={}", memberId, subscriptionDto.endpoint());
+        try {
+            subscriptionRepository.save(pushSubscription);
+            log.info("[구독 저장] memberId={}, endpoint={}", memberId, subscriptionDto.endpoint());
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateSubscriptionException();
+        }
     }
 
     public void sendPushNotification(PushMessageDto message) {

--- a/backend/src/main/java/com/dubu/backend/notification/domain/PushSubscription.java
+++ b/backend/src/main/java/com/dubu/backend/notification/domain/PushSubscription.java
@@ -2,6 +2,7 @@ package com.dubu.backend.notification.domain;
 
 import com.dubu.backend.global.domain.BaseTimeEntity;
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.notification.dto.PushSubscriptionDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,6 +11,9 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "end_point", "p256dh", "auth"})
+})
 public class PushSubscription extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,4 +31,13 @@ public class PushSubscription extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String auth;
+
+    public static PushSubscription createSubscription(Member member, PushSubscriptionDto pushSubscriptionDto) {
+        return PushSubscription.builder()
+                .member(member)
+                .endPoint(pushSubscriptionDto.endpoint())
+                .p256dh(pushSubscriptionDto.keys().p256dh())
+                .auth(pushSubscriptionDto.keys().auth())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/dubu/backend/notification/exception/DuplicateSubscriptionException.java
+++ b/backend/src/main/java/com/dubu/backend/notification/exception/DuplicateSubscriptionException.java
@@ -1,0 +1,16 @@
+package com.dubu.backend.notification.exception;
+
+import com.dubu.backend.global.exception.ConflictException;
+
+import static com.dubu.backend.global.exception.ErrorCode.DUPLICATE_SUBSCRIPTION;
+
+public class DuplicateSubscriptionException extends ConflictException {
+    public DuplicateSubscriptionException() {
+        super(DUPLICATE_SUBSCRIPTION.getMessage());
+    }
+
+    @Override
+    public String getErrorCode() {
+        return DUPLICATE_SUBSCRIPTION.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -82,7 +82,12 @@ public class PlanService {
 
         taskSchedulerService.scheduleFeedbackStatusUpdate(memberId, newPlan);
 
-        PushMessageDto message = new PushMessageDto(memberId, newPlan.getId(), "안녕", "문희상");
+        PushMessageDto message = new PushMessageDto(
+                memberId,
+                newPlan.getId(),
+                "잘 도착하셨나요? 30분 뒤면 오늘 한 일을 체크할 수 없어요😭",
+                "얼른 돌아와서 오늘 한 일을 체크하고 피드백을 남겨보세요~"
+        );
         pushMessageProducer.sendDelayedPush(message);
 
         return newPlan.getId();

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
@@ -6,7 +6,6 @@ import com.dubu.backend.plan.dto.request.PlanCreateRequest;
 import com.dubu.backend.todo.entity.Todo;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +37,12 @@ public class Path extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private TrafficType trafficType;
 
+    @Column(columnDefinition = "SMALLINT")
+    private Integer subwayCode;
+
+    @Column(length = 20)
+    private String busNumber;
+
     @Column(nullable = false, length = 20)
     private String startName;
 
@@ -54,6 +59,8 @@ public class Path extends BaseTimeEntity {
         return Path.builder()
                 .plan(plan)
                 .trafficType(TrafficType.from(pathRequest.trafficType()))
+                .subwayCode(pathRequest.subwayCode())
+                .busNumber(pathRequest.busNumber())
                 .startName(pathRequest.startName())
                 .endName(pathRequest.endName())
                 .sectionTime(pathRequest.sectionTime())

--- a/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
@@ -2,7 +2,6 @@ package com.dubu.backend.plan.dto.response;
 
 import com.dubu.backend.plan.domain.Path;
 import com.dubu.backend.plan.domain.Plan;
-import com.dubu.backend.plan.domain.enums.TrafficType;
 import com.dubu.backend.todo.entity.Todo;
 
 import java.time.LocalDateTime;
@@ -38,8 +37,8 @@ public record PlanRecentResponse(
                     path.getId(),
                     path.getTrafficType().name(),
                     path.getSectionTime(),
-                    path.getTrafficType() == TrafficType.SUBWAY ? path.getPlan().getId().intValue() : null,
-                    path.getTrafficType() == TrafficType.BUS ? path.getStartName() : null,
+                    path.getSubwayCode(),
+                    path.getBusNumber(),
                     path.getStartName(),
                     path.getEndName(),
                     path.getTodos().stream().map(PathTodoResponse::from).toList()


### PR DESCRIPTION
## Issue Number
#168 

## As-Is
<!-- 문제 상황 정의 -->
알림 구독 저장 시 중복 로직 추가합니다.

## To-Be
<!-- 변경 사항 -->
- [x] 알림 구독 정보 등록 API 수정
    - [x] p256dh, auth 중복 처리 로직 추가

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `ConflictException` class for better error handling.
  - Added a `DuplicateSubscriptionException` for clearer feedback on subscription conflicts.
  - Implemented a unique constraint for subscriptions to prevent duplicates in the database.
  - Expanded the `Path` class to include `subwayCode` and `busNumber` for enhanced transport information.
  - Enhanced user interaction with a more detailed push message after saving a new plan.

- **Bug Fixes**
  - Updated API response codes and messages for duplicate subscription scenarios to enhance clarity.

- **Refactor**
  - Streamlined the subscription creation process and improved error handling in the notification service.
  - Simplified the logic for assigning `subwayCode` and `busNumber` in the response DTO.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->