### PR TITLE
[FEAT] 이동 중 페이지에서 할 일이 속한 경로를 수정하는 기능 구현

### DIFF
--- a/backend/src/main/java/com/dubu/backend/todo/controller/TodoApi.java
+++ b/backend/src/main/java/com/dubu/backend/todo/controller/TodoApi.java
@@ -3,10 +3,13 @@ package com.dubu.backend.todo.controller;
 import com.dubu.backend.global.domain.PageResponse;
 import com.dubu.backend.global.domain.SuccessResponse;
 import com.dubu.backend.todo.dto.common.Cursor;
+import com.dubu.backend.todo.dto.common.TodoIdentifier;
 import com.dubu.backend.todo.dto.enums.TodoRequestType;
 import com.dubu.backend.todo.dto.request.*;
 import com.dubu.backend.todo.dto.response.TodoInfo;
 import com.dubu.backend.todo.dto.response.TodoSuccessResponse;
+import com.dubu.backend.todo.service.TodoQueryService;
+import com.dubu.backend.todo.service.impl.PathTodoManagementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,6 +25,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Locale;
+
+import static com.dubu.backend.todo.dto.enums.TodoRequestType.PATH;
 
 @Tag(name = "Todo API", description = "할 일 관리 API")
 public interface TodoApi {
@@ -1465,6 +1470,89 @@ public interface TodoApi {
             @Nullable @ModelAttribute Cursor cursor,
             @ModelAttribute RecommendTodoQueryRequest request);
 
+
+    @Operation(summary = "할 일의 경로 수정", description = "드래그-드랍을 하여 할 일의 경로를 수정한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200",
+                    description = "할 일의 경로 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(
+                                    implementation = TodoSuccessResponse.class,
+                                    description = "할 일 성공 응답"
+                            ),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "할 일의 경로 수정 성공",
+                                            value = "NO CONTENT"
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(responseCode = "400",
+                    description = """
+                        다음 경우에 발생할 수 있습니다.
+                        1. 회원의 상태가 해당 API를 호출할 없는 경우 (INVALID_MEMBER_STATUS)
+                        2. 할 일 타입과 요청 타입이 일치하지 않은 경우 (TODO_TYPE_MISMATCH)
+                    """,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(name = "유효하지 않은 회원의 상태 예시",
+                                            value = """
+                                            {
+                                                "errorCode": "INVALID_MEMBER_STATUS",
+                                                "message": "회원의 상태가 STOP인 경우 해당 API를 이용할 수 없습니다."
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(name = "일치하지 않은 할 일 타입과 요청 타입 예시",
+                                            value = """
+                                                    {
+                                                        "errorCode": "TODO_TYPE_MISMATCH",
+                                                        "message": "할 일의 타입과 요청 타입이 일치하지 않습니다. 할 일 타입 = SCHEDULED, 요청 타입 = IN_PROGRESS"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+
+            ),
+            @ApiResponse(responseCode = "404",
+                    description = """
+                        다음 경우에 발생할 수 있습니다:
+                        1. 회원을 찾을 수 없는 경우 (MEMBER_NOT_FOUND)
+                        2. 경로를 찾을 수 없는 경우 (PATH_NOT_FOUND)
+                    """,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(name = "회원 미존재 예시",
+                                            value = """
+                                            {
+                                              "errorCode": "MEMBER_NOT_FOUND",
+                                              "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(name = "경로 미존재 예시",
+                                            value = """
+                                            {
+                                                "errorCode": "PATH_NOT_FOUND",
+                                                "message": "경로를 찾을 수 없습니다. pathId : 9999"
+                                            }
+                                            """
+                                    )
+                            }
+                    )
+            ),
+    })
+    void patchTodoPath(
+            @RequestAttribute("memberId") Long memberId,
+            @Parameter(description = "할일 ID", required = true) @RequestParam Long todoId,
+            @ModelAttribute TodoPathUpdateRequest request);
 
     @Schema(name = "ErrorResponseExample", description = "에러 응답 예시")
     class ErrorResponseExample {

--- a/backend/src/main/java/com/dubu/backend/todo/controller/TodoController.java
+++ b/backend/src/main/java/com/dubu/backend/todo/controller/TodoController.java
@@ -183,4 +183,15 @@ public class TodoController implements TodoApi{
         TodoQueryService todoQueryService = todoQueryServiceRegistry.getService(PATH.getQueryServiceName());
         return new SuccessResponse<>(((TargetTodoQueryService)todoQueryService).findTargetTodos(new TodoIdentifier(memberId, null, pathId)));
     }
+
+    @PatchMapping("/path")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void patchTodoPath(
+            @RequestAttribute("memberId") Long memberId,
+            @RequestParam Long todoId,
+            @ModelAttribute TodoPathUpdateRequest request)
+    {
+        TodoManagementService todoManagementService = todoManagementServiceRegistry.getService(PATH.getManagementServiceName());
+        ((PathTodoManagementService)todoManagementService).modifyTodoPath(new TodoIdentifier(memberId, todoId, null), request);
+    }
 }

--- a/backend/src/main/java/com/dubu/backend/todo/dto/request/TodoPathUpdateRequest.java
+++ b/backend/src/main/java/com/dubu/backend/todo/dto/request/TodoPathUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.dubu.backend.todo.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "할 일 경로 수정 요청")
+public record TodoPathUpdateRequest(
+        @Schema(description = "새로운 경로 ID", example = "9999") Long newPathId) {
+}

--- a/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
@@ -118,6 +118,10 @@ public class Todo extends BaseTimeEntity {
         this.isCompleted = isCompleted;
     }
 
+    public void updatePath(Path path){
+        this.path = path;
+    }
+
     public void updateTodo(String title, Category category, TodoDifficulty difficulty, String memo){
         if(title != null) updateTitle(title);
         if(category != null) updateCategory(category);

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/PathTodoManagementService.java
@@ -9,10 +9,7 @@ import com.dubu.backend.plan.exception.InvalidMemberStatusException;
 import com.dubu.backend.plan.exception.PathNotFoundException;
 import com.dubu.backend.plan.infra.repository.PathRepository;
 import com.dubu.backend.todo.dto.common.TodoIdentifier;
-import com.dubu.backend.todo.dto.request.TodoCompletionToggleRequest;
-import com.dubu.backend.todo.dto.request.TodoCreateFromArchivedRequest;
-import com.dubu.backend.todo.dto.request.TodoCreateRequest;
-import com.dubu.backend.todo.dto.request.TodoUpdateRequest;
+import com.dubu.backend.todo.dto.request.*;
 import com.dubu.backend.todo.dto.response.TodoInfo;
 import com.dubu.backend.todo.dto.response.TodoManageResult;
 import com.dubu.backend.todo.entity.Category;
@@ -158,5 +155,23 @@ public class PathTodoManagementService implements TodoManagementService {
         }
 
         todo.updateCompletedStatus(request.isCompleted());
+    }
+
+    public void modifyTodoPath(TodoIdentifier identifier, TodoPathUpdateRequest request){
+        Member member = memberRepository.findById(identifier.memberId()).orElseThrow(() -> new MemberNotFoundException(identifier.memberId()));
+
+        if (!member.getStatus().equals(Status.MOVE)) {
+            throw new InvalidMemberStatusException(member.getStatus().name());
+        }
+
+        Todo todo = todoRepository.findById(identifier.todoId()).orElseThrow(() -> new TodoNotFoundException(identifier.todoId()));
+
+        if(!todo.getType().equals(TodoType.IN_PROGRESS)){
+            throw new TodoTypeMismatchException(todo.getType(), TodoType.IN_PROGRESS);
+        }
+
+        Path newPath = pathRepository.findById(request.newPathId()).orElseThrow(() -> new PathNotFoundException(request.newPathId()));
+
+        todo.updatePath(newPath);
     }
 }


### PR DESCRIPTION
## Issue Number

close #178 
## As-Is
<!-- 문제 상황 정의 -->
이동 중 페이지에서 할 일이 속한 경로를 수정하는 기능 구현한다.

## To-Be
<!-- 변경 사항 -->
- [x] 할 일 아이디, 새로운 경로 아이디를 입력으로 받아 경로 아이디 값을 새로운 경로 아이디로 수정한다.
- [x] 스웨거 명세 추가

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a drag-and-drop capability to update the categorization of todo items. This user-friendly enhancement allows you to easily change the grouping or location of your tasks, streamlining management and ensuring a smoother task organization experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->