### PR TITLE
[FIX] 카카오 로그인 리다이렉트 수정

### DIFF
--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -3,8 +3,13 @@ import fetchClient from './fetchClient';
 import { API_URL } from '@/constants/url';
 import { KakaoLogin } from '@/types/auth';
 
+const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
 export const kakaoLogin = () => {
-  window.location.href = API_URL.loginKakao;
+  const KAKAO_LOGIN = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
+
+  window.location.href = KAKAO_LOGIN;
 };
 
 export const kakaoLoginAuth = async (code: string): Promise<KakaoLogin> => {


### PR DESCRIPTION
## Issue Number
close #166 
## As-Is
<!-- 문제 상황 정의 -->
- 카카오 로그인 시 서버로 리다이렉트됨
## To-Be
<!-- 변경 사항 -->
- [x] 카카오 로그인 버튼 클릭 시 바로 카카오 로그인 화면이 뜨도록 수정

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Kakao login process to dynamically generate the login URL using environment-based configurations for a more flexible authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->