### PR TITLE
[FIX] 이동완료시 각 할 일 별 시간 체크 로직 변경

### DIFF
--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -164,14 +164,12 @@ public class PlanService {
 
         recentPlan.getPaths().forEach(path -> {
             List<Todo> todos = path.getTodos();
-            long doneCount = todos.stream().filter(todo -> todo.getIsCompleted() == Boolean.TRUE).count();
+            List<Todo> doneTodos = todos.stream().filter(todo -> todo.getIsCompleted() == Boolean.TRUE).toList();
 
-            if (doneCount > 0) {
-                int sectionTimePerTodo = path.getSectionTime() / todos.size();
+            if (!doneTodos.isEmpty()) {
+                int sectionTimePerTodo = path.getSectionTime() / doneTodos.size();
 
-                todos.stream()
-                        .filter(todo -> todo.getIsCompleted() == Boolean.TRUE)
-                        .forEach(doneTodo -> doneTodo.updateSpentTime(sectionTimePerTodo));
+                doneTodos.forEach(doneTodo -> doneTodo.updateSpentTime(sectionTimePerTodo));
             }
 
             todos.forEach(todo -> todo.updateTodoType(TodoType.DONE));


### PR DESCRIPTION
## Issue Number
#187

## As-Is
<!-- 문제 상황 정의 -->
이동완료시 각 할 일 별 시간 체크 로직 변경합니다.
기존의 방식 : 경로 별 시간에서 계획한 할 일 중 수행한 일 비율에 맞춰서 시간을 분배 -> n(계획한 일 개수)분의 1
변경된 방식 : 경로 별 시간에서 수행한 일의 개수에 따른 시간을 분배 -> n(계획한 일 중 수행한 일 개수)분의 1로 시간을 분배

## To-Be
<!-- 변경 사항 -->
- [x] 변경된 방식으로 할 일 시간 체크 로직 수정

## Check List

- [ ] 테스트가 전부 통과되었나요?
- [ ] 모든 commit이 push 되었나요?
- [ ] merge할 branch를 확인했나요?
- [ ] Assignee를 지정했나요?
- [ ] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
