### PR TITLE
[FIX] 지도(공유)페이지에서 카테고리 랭킹에 대한 버그 수정

### DIFF
--- a/backend/src/main/java/com/dubu/backend/share/dto/response/ShareInfo.java
+++ b/backend/src/main/java/com/dubu/backend/share/dto/response/ShareInfo.java
@@ -7,7 +7,7 @@ public record ShareInfo(List<MemberInfo> memberInfos, List<CategoryRankInfo> cat
     public static ShareInfo of(List<MemberInfo> memberInfos, List<CategoryRankInfo> categoryRankInfos){
         return new ShareInfo(
                 memberInfos,
-                categoryRankInfos.subList(0, 3)
+                categoryRankInfos.size() <= 3? categoryRankInfos: categoryRankInfos.subList(0, 3)
                 );
     }
 


### PR DESCRIPTION
## Issue Number

close #191 
## As-Is
<!-- 문제 상황 정의 -->
지도(공유)페이지에서 카테고리 랭킹에 대한 버그를 수정한다.

## To-Be
<!-- 변경 사항 -->
- [x] 수집한 카테고리 랭킹(리스트)에 대한 길이가 3보다 큰지, 작은지에 대한 확인하는 로직을 추가하고 3보다 작다면 바로 응답으로 전달한다.


## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
