### PR TITLE
[REFACTOR] 유저 상태에 따라 리다이렉트시킬 때 화면 깜박임 개선

### DIFF
--- a/frontend/src/constants/queryClient.ts
+++ b/frontend/src/constants/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();

--- a/frontend/src/hooks/useRedirectByMemberStatus.ts
+++ b/frontend/src/hooks/useRedirectByMemberStatus.ts
@@ -11,9 +11,11 @@ const useRedirectByMemberStatus = () => {
   const navigate = useNavigate();
   const { dateType } = useQueryParamsDate();
 
-  if (isError) {
-    navigate('/landing');
-  }
+  useEffect(() => {
+    if (isError) {
+      navigate('/landing');
+    }
+  }, [isError, navigate]);
 
   useEffect(() => {
     if (!memberStatus) return;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router';
@@ -6,6 +6,7 @@ import { ThemeProvider } from 'styled-components';
 
 import ToastProvider from './components/Toast/ToastProvider';
 import Viewport from './components/Viewport/Viewport';
+import { queryClient } from './constants/queryClient';
 import { OverlayProvider } from './providers/OverlayProvider';
 import { router } from './router';
 import GlobalStyle from './styles/GlobalStyle.js';
@@ -20,8 +21,6 @@ const enableMocking = async () => {
 
   return await worker.start({ onUnhandledRequest: 'bypass' });
 };
-
-const queryClient = new QueryClient();
 
 enableMocking().then(() => {
   createRoot(document.getElementById('root')!).render(

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router';
 
 import FlexPageLayout from './layout/FlexPageLayout';
+import memberStatusLoader from './memberStatusLoader';
 
 import DayStatisticsPage from '@/pages/DayStatisticsPage';
 import EditPage from '@/pages/EditPage';
@@ -22,6 +23,7 @@ export const router = createBrowserRouter([
   {
     path: '/',
     element: <MainPage />,
+    loader: memberStatusLoader,
   },
   {
     path: '/landing',
@@ -40,6 +42,7 @@ export const router = createBrowserRouter([
   {
     path: '/onboarding',
     element: <OnboardingPage />,
+    loader: memberStatusLoader,
   },
   {
     path: '/route-select',
@@ -52,6 +55,7 @@ export const router = createBrowserRouter([
       {
         index: true,
         element: <PlanPage />,
+        loader: memberStatusLoader,
       },
     ],
   },
@@ -82,10 +86,12 @@ export const router = createBrowserRouter([
   {
     path: '/feedback',
     element: <FeedbackPage />,
+    loader: memberStatusLoader,
   },
   {
     path: '/login/kakao',
     element: <KakaoLoginPage />,
+    loader: memberStatusLoader,
   },
   {
     path: '/statistics/week',

--- a/frontend/src/router/memberStatusLoader.ts
+++ b/frontend/src/router/memberStatusLoader.ts
@@ -1,0 +1,45 @@
+import { redirect } from 'react-router';
+
+import { getMemberStatus } from '@/api/member';
+import { DATE_TYPE } from '@/constants/config';
+import { queryClient } from '@/constants/queryClient';
+import { QUERY_KEY } from '@/constants/queryKey';
+
+const MEMBER_STATUS = {
+  onboarding: 'ONBOARDING',
+  stop: 'STOP',
+  move: 'MOVE',
+  feedback: 'FEEDBACK',
+};
+
+// 접근 제한이 필요한 라우터의 loader 설정
+const memberStatusLoader = async ({ request }: { request: Request }) => {
+  try {
+    const memberStatus = await queryClient.fetchQuery({
+      queryKey: [QUERY_KEY.memberStatus],
+      queryFn: getMemberStatus,
+    });
+
+    const url = new URL(request.url);
+    const currentPath = url.pathname;
+    const dateType = url.searchParams.get('dateType') || DATE_TYPE.TODAY;
+    const mainURL = dateType === DATE_TYPE.TODAY ? '/' : `/?dateType=${dateType}`;
+
+    if (memberStatus.status === MEMBER_STATUS.onboarding && currentPath !== '/onboarding') {
+      return redirect('/onboarding');
+    } else if (memberStatus.status === MEMBER_STATUS.stop && currentPath !== '/') {
+      return redirect(mainURL);
+    } else if (memberStatus.status === MEMBER_STATUS.move && currentPath !== '/plan') {
+      return redirect('/plan');
+    } else if (memberStatus.status === MEMBER_STATUS.feedback && currentPath !== '/feedback') {
+      return redirect('/feedback');
+    }
+
+    return memberStatus;
+  } catch (error) {
+    // TODO: 로그인 만료 시 재로그인 로직 추가
+    return redirect('/landing');
+  }
+};
+
+export default memberStatusLoader;


### PR DESCRIPTION
## Issue Number
close #197 

## As-Is
<!-- 문제 상황 정의 -->
- 페이지 이동 후 유저 상태 API 응답을 받고 리다이렉트하는 경우 깜박임 발생

## To-Be
<!-- 변경 사항 -->
- 컴포넌트를 렌더링하기 전에 loader 함수가 실행되서 유저 상태에 따라 redirect 시킴으로써 불필요한 컴포넌트 렌더링과 깜박임을 제거함으로써 UX 개선

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

| ❌ before | ✅ after |
|-|-|
|<video src="https://github.com/user-attachments/assets/e0dbebd7-553b-46a3-83ae-436cf8d627b9" /> | <video src="https://github.com/user-attachments/assets/20e35877-9115-4ff5-9f77-b0d75c8da498" />

## (Optional) Additional Description

서버가 사용자의 상태를 관리하고 있어서 리다이렉트 보내는 커스텀훅을 사용하고 있었습니다. 이러다보니 페이지가 먼저 전환되고 API 응답값이 나중에 오게 되는데, 응답값이 느릴수록 전환이 늦어서 사용자 경험에 좋지 않았습니다. 또한 응답이 빠르더라도 화면이 깜박이는 것처럼 보이기 때문에, loader를 적용하여 페이지 컴포넌트가 렌더링되기 전에 판단하고 redirect 시켜 개선하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved server state and caching management for a more consistent experience.
	- Enhanced navigation flows that automatically direct users to the appropriate page based on your membership status—ensuring smoother transitions during onboarding, planning, feedback, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->