### PR TITLE
[FIX] 주간 통계, 일간 통계 조회 시 사용자 생성 시간 데이터 포함

### DIFF
--- a/backend/src/main/java/com/dubu/backend/statistic/controller/StatisticApi.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/controller/StatisticApi.java
@@ -34,52 +34,45 @@ public interface StatisticApi {
                                     @ExampleObject(
                                             name = "일일 통계 데이터가 있을 경우",
                                             value = """
-                                            {
-                                                "data": {
-                                                    "totalMoveTime": 224,
-                                                    "totalUsageTime": 100,
-                                                    "feedbacks": [
-                                                        {
-                                                            "mood": "DISSATISFIED",
-                                                            "memo": "Feedback P"
-                                                        },
-                                                        {
-                                                            "mood": "DISSATISFIED",
-                                                            "memo": "Feedback F"
-                                                        },
-                                                        {
+                                                    {
+                                                      "data": {
+                                                        "memberCreateDate": "2023-02-05",
+                                                        "totalUsageTime": 264,
+                                                        "totalTodoCount": 10,
+                                                        "feedbacks": [
+                                                          {
                                                             "mood": "MODERATE",
-                                                            "memo": "Feedback G"
-                                                        }
-                                                    ],
-                                                    "categoryTodoCounts": [
-                                                        {
-                                                            "category": "OTHERS",
-                                                            "count": 10
-                                                        },
-                                                        {
-                                                            "category": "ENGLISH",
-                                                            "count": 10
-                                                        },
-                                                        {
-                                                            "category": "LANGUAGE",
-                                                            "count": 4
-                                                        },
-                                                        {
-                                                            "category": "NEWS",
-                                                            "count": 4
-                                                        },
-                                                        {
+                                                            "memo": "feedback_974765"
+                                                          },
+                                                          {
+                                                            "mood": "SATISFIED",
+                                                            "memo": "feedback_978139"
+                                                          },
+                                                          {
+                                                            "mood": "MODERATE",
+                                                            "memo": "feedback_983482"
+                                                          }
+                                                        ],
+                                                        "categoryTodoCounts": [
+                                                          {
                                                             "category": "HOBBY",
                                                             "count": 4
-                                                        },
-                                                        {
-                                                            "category": "READING",
-                                                            "count": 4
-                                                        }
-                                                    ]
-                                                }
-                                            }
+                                                          },
+                                                          {
+                                                            "category": "NEWS",
+                                                            "count": 3
+                                                          },
+                                                          {
+                                                            "category": "ENGLISH",
+                                                            "count": 2
+                                                          },
+                                                          {
+                                                            "category": "LANGUAGE",
+                                                            "count": 1
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
                                             """
                                     ),
                                     @ExampleObject(
@@ -130,89 +123,86 @@ public interface StatisticApi {
                                     @ExampleObject(
                                             name = "주간 통계 데이터가 있을 경우",
                                             value = """
-                                                    {
-                                                        "data": {
-                                                          "dayAvailableTimes": [
-                                                            {
-                                                              "date": "2025-01-13",
-                                                              "availableTime": 69
-                                                            },
-                                                            {
-                                                              "date": "2025-01-14",
-                                                              "availableTime": 132
-                                                            },
-                                                            {
-                                                              "date": "2025-01-15",
-                                                              "availableTime": 40
-                                                            },
-                                                            {
-                                                              "date": "2025-01-16",
-                                                              "availableTime": 0
-                                                            },
-                                                            {
-                                                              "date": "2025-01-17",
-                                                              "availableTime": 87
-                                                            },
-                                                            {
-                                                              "date": "2025-01-18",
-                                                              "availableTime": 40
-                                                            },
-                                                            {
-                                                              "date": "2025-01-19",
-                                                              "availableTime": 200
-                                                            }
-                                                          ],
-                                                          "totalTodoCount": 37,
-                                                          "lastWeekDiff": 173,
-                                                          "totalAvailableTime": 568,
-                                                          "moodCounts": [
-                                                            {
-                                                              "mood": "DISSATISFIED",
-                                                              "count": 3
-                                                            },
-                                                            {
-                                                              "mood": "MODERATE",
-                                                              "count": 5
-                                                            },
-                                                            {
-                                                              "mood": "SATISFIED",
-                                                              "count": 6
-                                                            }
-                                                          ],
-                                                          "categoryTodoCounts": [
-                                                            {
-                                                              "category": "NEWS",
-                                                              "usageTime": 53,
-                                                              "count": 9
-                                                            },
-                                                            {
-                                                              "category": "ENGLISH",
-                                                              "usageTime": 46,
-                                                              "count": 6
-                                                            },
-                                                            {
-                                                              "category": "OTHERS",
-                                                              "usageTime": 35,
-                                                              "count": 6
-                                                            },
-                                                            {
-                                                              "category": "HOBBY",
-                                                              "usageTime": 29,
-                                                              "count": 5
-                                                            },
-                                                            {
-                                                              "category": "LANGUAGE",
-                                                              "usageTime": 27,
-                                                              "count": 6
-                                                            },
-                                                            {
-                                                              "category": "READING",
-                                                              "usageTime": 23,
-                                                              "count": 5
-                                                            }
-                                                          ]
-                                                        }
-                                                      }
+                                            {
+                                              "data": {
+                                                "memberCreateDate": "2023-02-05",
+                                                "dayAvailableTimes": [
+                                                  {
+                                                    "date": "2025-01-27",
+                                                    "availableTime": 176
+                                                  },
+                                                  {
+                                                    "date": "2025-01-28",
+                                                    "availableTime": 46
+                                                  },
+                                                  {
+                                                    "date": "2025-01-29",
+                                                    "availableTime": 41
+                                                  },
+                                                  {
+                                                    "date": "2025-01-30",
+                                                    "availableTime": 124
+                                                  },
+                                                  {
+                                                    "date": "2025-01-31",
+                                                    "availableTime": 34
+                                                  },
+                                                  {
+                                                    "date": "2025-02-01",
+                                                    "availableTime": 0
+                                                  },
+                                                  {
+                                                    "date": "2025-02-02",
+                                                    "availableTime": 0
+                                                  }
+                                                ],
+                                                "totalTodoCount": 36,
+                                                "lastWeekDiff": -102,
+                                                "totalAvailableTime": 421,
+                                                "moodCounts": [
+                                                  {
+                                                    "mood": "MODERATE",
+                                                    "count": 5
+                                                  },
+                                                  {
+                                                    "mood": "SATISFIED",
+                                                    "count": 6
+                                                  }
+                                                ],
+                                                "categoryTodoCounts": [
+                                                  {
+                                                    "category": "NEWS",
+                                                    "usageTime": 37,
+                                                    "count": 8
+                                                  },
+                                                  {
+                                                    "category": "OTHERS",
+                                                    "usageTime": 35,
+                                                    "count": 5
+                                                  },
+                                                  {
+                                                    "category": "LANGUAGE",
+                                                    "usageTime": 34,
+                                                    "count": 6
+                                                  },
+                                                  {
+                                                    "category": "ENGLISH",
+                                                    "usageTime": 29,
+                                                    "count": 6
+                                                  },
+                                                  {
+                                                    "category": "HOBBY",
+                                                    "usageTime": 24,
+                                                    "count": 6
+                                                  },
+                                                  {
+                                                    "category": "READING",
+                                                    "usageTime": 16,
+                                                    "count": 5
+                                                  }
+                                                ]
+                                              }
+                                            }
                                             """
                                     ),
                                     @ExampleObject(

--- a/backend/src/main/java/com/dubu/backend/statistic/dto/response/DayStatisticInfo.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/dto/response/DayStatisticInfo.java
@@ -2,21 +2,30 @@ package com.dubu.backend.statistic.dto.response;
 
 import com.dubu.backend.plan.domain.Feedback;
 import com.dubu.backend.statistic.service.collection.CategoryTodoStatistics;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record DayStatisticInfo(
-        int totalMoveTime,
-        int totalUsageTime,
+        LocalDate memberCreateDate,
+        Integer totalUsageTime,
+        Integer totalTodoCount,
         List<FeedbackInfo> feedbacks,
         List<CategoryTodoInfo> categoryTodoCounts
 ) {
-    public static DayStatisticInfo of(int totalMoveTime, int totalUsageTime, List<Feedback> feedbacks, Map<String, CategoryTodoStatistics.TimeCount> categoryTodoCount){
+    public static DayStatisticInfo of(LocalDate memberCreateDate){
+        return new DayStatisticInfo(memberCreateDate, null, null, null, null);
+    }
+    public static DayStatisticInfo of(LocalDate memberCreateDate, int totalUsageTime, int totalTodoCount, List<Feedback> feedbacks, Map<String, CategoryTodoStatistics.TimeCount> categoryTodoCount){
 
         return new DayStatisticInfo(
-                totalMoveTime,
+                memberCreateDate,
                 totalUsageTime,
+                totalTodoCount,
                 FeedbackInfo.fromFeedbacks(feedbacks),
                 CategoryTodoInfo.fromCategoryTodoTimeCount(categoryTodoCount)
         );

--- a/backend/src/main/java/com/dubu/backend/statistic/dto/response/WeekStatisticInfo.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/dto/response/WeekStatisticInfo.java
@@ -2,22 +2,29 @@ package com.dubu.backend.statistic.dto.response;
 
 import com.dubu.backend.plan.domain.enums.Mood;
 import com.dubu.backend.statistic.service.collection.CategoryTodoStatistics;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record WeekStatisticInfo(
+        LocalDate memberCreateDate,
         List<DayAvailableTime> dayAvailableTimes,
-        int totalTodoCount,
-        int lastWeekDiff,
-        int totalAvailableTime,
+        Integer totalTodoCount,
+        Integer lastWeekDiff,
+        Integer totalAvailableTime,
         List<MoodCountInfo> moodCounts,
         List<CategoryTodoInfo> categoryTodoCounts
 ) {
-    public static WeekStatisticInfo of(Map<LocalDate, Integer> dateUsageTime, int totalTodoCount, int lastWeekDiff, int totalAvailableTime, Map<Mood, Integer> moodCount, Map<String, CategoryTodoStatistics.TimeCount> categoryTodoTimeCount){
+    public static WeekStatisticInfo of(LocalDate memberCreateDate) {
+        return new WeekStatisticInfo(memberCreateDate, null, null, null, null, null, null);
+    }
+    public static WeekStatisticInfo of(LocalDate memberCreateDate, Map<LocalDate, Integer> dateUsageTime, int totalTodoCount, int lastWeekDiff, int totalAvailableTime, Map<Mood, Integer> moodCount, Map<String, CategoryTodoStatistics.TimeCount> categoryTodoTimeCount){
         return new WeekStatisticInfo(
+                memberCreateDate,
                 DayAvailableTime.fromDateUsageTime(dateUsageTime),
                 totalTodoCount,
                 lastWeekDiff,

--- a/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
@@ -48,10 +48,10 @@ public class StatisticServiceImpl implements StatisticService {
         List<Path> dayPaths = pathRepository.findByPlansAndTypeAndIsCompleted(dayPlans, TodoType.DONE, true);
 
         if(dayPlans == null || dayPlans.isEmpty() || dayPaths == null || dayPaths.isEmpty()){
-            return null;
+            return DayStatisticInfo.of(member.getCreatedAt().toLocalDate());
         }
 
-        return buildDailyStatisticInfo(categories, dayPlans, dayPaths);
+        return buildDailyStatisticInfo(member.getCreatedAt().toLocalDate(), categories, dayPlans, dayPaths);
     }
 
     @Override
@@ -67,37 +67,36 @@ public class StatisticServiceImpl implements StatisticService {
 //        List<Path> thisWeekPaths = pathRepository.findByPlansAndTypeAndIsCompleted(thisWeekPlans, TodoType.DONE, true);
 
         if(thisWeekPlans == null || thisWeekPlans.isEmpty() || pathIdsOfWeekPlans == null || pathIdsOfWeekPlans.isEmpty() || completedTodos == null || completedTodos.isEmpty()){
-            return null;
+            return WeekStatisticInfo.of(member.getCreatedAt().toLocalDate());
         }
 
         List<Plan> lastWeekPlans = planRepository.findWithPathsByMemberAndCreatedAtBetween(member, date.minusWeeks(1).atStartOfDay(), date.minusDays(1).atTime(LocalTime.MAX));
 
-        return buildWeekStatisticInfoUsingPathIds(date, categories, thisWeekPlans, completedTodos, lastWeekPlans);
+        return buildWeekStatisticInfoUsingPathIds(member.getCreatedAt().toLocalDate(), date, categories, thisWeekPlans, completedTodos, lastWeekPlans);
     }
 
 
-    private DayStatisticInfo buildDailyStatisticInfo(List<Category> categories, List<Plan> plans, List<Path> paths) {
-        int totalMoveTime = 0;
+    private DayStatisticInfo buildDailyStatisticInfo(LocalDate memberCreateDate, List<Category> categories, List<Plan> plans, List<Path> paths) {
         int totalUsageTime = 0;
+        int totalTodoCount = 0;
         List<Feedback> feedbacks = new ArrayList<>();
         CategoryTodoStatistics categoryTodoStatistics = new CategoryTodoStatistics(categories);
 
         for(Plan plan: plans){
-            totalMoveTime += plan.getTotalTime();
+            totalUsageTime += plan.getTotalTime();
             feedbacks.add(plan.getFeedback());
         }
-
         for(Path path: paths){
             for(Todo todo: path.getTodos()){
                 categoryTodoStatistics.countDoneTodo(todo);
-                totalUsageTime += todo.getSpentTime();
+                totalTodoCount++;
             }
         }
 
-        return DayStatisticInfo.of(totalMoveTime, totalUsageTime, feedbacks, categoryTodoStatistics.getCategoryTodoTimeCount());
+        return DayStatisticInfo.of(memberCreateDate, totalUsageTime, totalTodoCount, feedbacks, categoryTodoStatistics.getCategoryTodoTimeCount());
     }
 
-    private WeekStatisticInfo buildWeekStatisticInfo(LocalDate startDate, List<Category> categories, List<Plan> thisWeekPlans, List<Plan> lastWeekPlans){
+    private WeekStatisticInfo buildWeekStatisticInfo(LocalDate memberCreateDate, LocalDate startDate, List<Category> categories, List<Plan> thisWeekPlans, List<Plan> lastWeekPlans){
         DateAvailableTimeStatistics dateAvailableTimeStatistics = new DateAvailableTimeStatistics(startDate);
         int totalAvailableTime = 0;
         int totalTodoCount = 0;
@@ -106,11 +105,10 @@ public class StatisticServiceImpl implements StatisticService {
 
         for(Plan plan: thisWeekPlans){
             LocalDate date = plan.getCreatedAt().toLocalDate();
-
+            totalAvailableTime += plan.getTotalTime();
             moodCountCollection.addMood(plan.getFeedback().getMood());
 
             for (Path path : plan.getPaths()) {
-                totalAvailableTime += path.getSectionTime();
                 dateAvailableTimeStatistics.addUsageTimeAtDate(date, path.getSectionTime());
                 for (Todo todo : path.getTodos()) {
                     totalTodoCount += 1;
@@ -121,10 +119,10 @@ public class StatisticServiceImpl implements StatisticService {
         // 저번 주와의 활용 가능 시간 차이
         int lastWeekDiff = totalAvailableTime - calculateWeeklyUsageTime(lastWeekPlans);
 
-        return WeekStatisticInfo.of(dateAvailableTimeStatistics.getDateUsageTime(), totalTodoCount, lastWeekDiff, totalAvailableTime, moodCountCollection.getMoodCount(), categoryTodoStatistics.getCategoryTodoTimeCount());
+        return WeekStatisticInfo.of(memberCreateDate, dateAvailableTimeStatistics.getDateUsageTime(), totalTodoCount, lastWeekDiff, totalAvailableTime, moodCountCollection.getMoodCount(), categoryTodoStatistics.getCategoryTodoTimeCount());
     }
 
-    private WeekStatisticInfo buildWeekStatisticInfoUsingPathIds(LocalDate startDate, List<Category> categories, List<Plan> thisWeekPlans, List<Todo> completedTodos, List<Plan> lastWeekPlans) {
+    private WeekStatisticInfo buildWeekStatisticInfoUsingPathIds(LocalDate memberCreateDate, LocalDate startDate, List<Category> categories, List<Plan> thisWeekPlans, List<Todo> completedTodos, List<Plan> lastWeekPlans) {
         DateAvailableTimeStatistics dateAvailableTimeStatistics = new DateAvailableTimeStatistics(startDate);
         int totalAvailableTime = 0;
         int totalTodoCount = 0;
@@ -152,7 +150,7 @@ public class StatisticServiceImpl implements StatisticService {
         // 저번 주와의 활용 가능한 시간 차이
         int lastWeekDiff = totalAvailableTime - calculateWeeklyUsageTime(lastWeekPlans);
 
-        return WeekStatisticInfo.of(dateAvailableTimeStatistics.getDateUsageTime(), totalTodoCount, lastWeekDiff, totalAvailableTime, moodCountCollection.getMoodCount(), categoryTodoStatistics.getCategoryTodoTimeCount());
+        return WeekStatisticInfo.of(memberCreateDate, dateAvailableTimeStatistics.getDateUsageTime(), totalTodoCount, lastWeekDiff, totalAvailableTime, moodCountCollection.getMoodCount(), categoryTodoStatistics.getCategoryTodoTimeCount());
     }
 
     // 활용 가능한 시간 계산


### PR DESCRIPTION
## Issue Number

close #202 
## As-Is
<!-- 문제 상황 정의 -->
주간 통계, 일간 통계 조회 시 전송하는 데이터를 수정한다.

## To-Be
<!-- 변경 사항 -->

- [x] 사용자의 created_at 정보를 이용하여 사용자의 생성 시간 정보를 응답에 포함시킨다.

- [x] 일일 통계에 이동 시간 데이터를 제외하고 총 할 일 개수 데이터르 추가한다.

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Daily and weekly statistics now include additional details such as member creation date, updated usage times, total todo counts, and refined breakdowns for feedback, moods, and categories.
- **Bug Fixes**
  - Improved response handling to consistently return default statistics when no data is available, ensuring clearer and more reliable information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->