### PR TITLE
[FIX] 통계 기능에서 한 일 유무 관계없이 계획이 있을 경우 관련 데이터 전송

### DIFF
--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
@@ -14,10 +14,10 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     @Query("SELECT p FROM Plan p LEFT JOIN FETCH p.feedback WHERE p.member.id = :memberId ORDER BY p.createdAt DESC LIMIT 1")
     Optional<Plan> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
 
-    @Query("SELECT p FROM Plan p JOIN FETCH p.feedback WHERE p.member = :member AND p.createdAt between :startTime AND :endTime")
+    @Query("SELECT p FROM Plan p JOIN FETCH p.feedback WHERE p.member = :member AND p.isCompleted = true AND p.createdAt between :startTime AND :endTime")
     List<Plan> findByMemberAndCreatedAtBetween(Member member, LocalDateTime startTime, LocalDateTime endTime);
 
-    @Query("SELECT p FROM Plan p JOIN FETCH p.feedback JOIN FETCH p.paths WHERE p.member = :member AND p.createdAt between :startTime AND :endTime")
+    @Query("SELECT p FROM Plan p JOIN FETCH p.feedback JOIN FETCH p.paths WHERE p.member = :member AND p.isCompleted = true AND p.createdAt between :startTime AND :endTime")
     List<Plan> findWithPathsByMemberAndCreatedAtBetween(Member member, LocalDateTime startTime, LocalDateTime endTime);
 
     // 통계 기능 최적화 작업을 위해 남겨둠

--- a/backend/src/main/java/com/dubu/backend/statistic/controller/StatisticApi.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/controller/StatisticApi.java
@@ -76,10 +76,31 @@ public interface StatisticApi {
                                             """
                                     ),
                                     @ExampleObject(
+                                            name = "계획은 있으나 한 일이 없는 경우",
+                                            value = """
+                                            {
+                                              "data": {
+                                                "memberCreateDate": "2023-02-05",
+                                                "totalUsageTime": 70,
+                                                "totalTodoCount": 0,
+                                                "feedbacks": [
+                                                  {
+                                                    "mood": "SATISFIED",
+                                                    "memo": "feedback_990214\\r"
+                                                  }
+                                                ],
+                                                "categoryTodoCounts": []
+                                              }
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
                                             name = "일일 통계 데이터가 없는 경우",
                                             value = """
                                             {
-                                                "data": null
+                                                "data": {
+                                                    "memberCreateDate" :"2025-02-17"
+                                                }
                                             }
                                             """
                                     ),
@@ -124,91 +145,142 @@ public interface StatisticApi {
                                             name = "주간 통계 데이터가 있을 경우",
                                             value = """
                                             {
-                                              "data": {
-                                                "memberCreateDate": "2023-02-05",
-                                                "dayAvailableTimes": [
-                                                  {
-                                                    "date": "2025-01-27",
-                                                    "availableTime": 176
-                                                  },
-                                                  {
-                                                    "date": "2025-01-28",
-                                                    "availableTime": 46
-                                                  },
-                                                  {
-                                                    "date": "2025-01-29",
-                                                    "availableTime": 41
-                                                  },
-                                                  {
-                                                    "date": "2025-01-30",
-                                                    "availableTime": 124
-                                                  },
-                                                  {
-                                                    "date": "2025-01-31",
-                                                    "availableTime": 34
-                                                  },
-                                                  {
-                                                    "date": "2025-02-01",
-                                                    "availableTime": 0
-                                                  },
-                                                  {
-                                                    "date": "2025-02-02",
-                                                    "availableTime": 0
-                                                  }
-                                                ],
-                                                "totalTodoCount": 36,
-                                                "lastWeekDiff": -102,
-                                                "totalAvailableTime": 421,
-                                                "moodCounts": [
-                                                  {
-                                                    "mood": "MODERATE",
-                                                    "count": 5
-                                                  },
-                                                  {
-                                                    "mood": "SATISFIED",
-                                                    "count": 6
-                                                  }
-                                                ],
-                                                "categoryTodoCounts": [
-                                                  {
-                                                    "category": "NEWS",
-                                                    "usageTime": 37,
-                                                    "count": 8
-                                                  },
-                                                  {
-                                                    "category": "OTHERS",
-                                                    "usageTime": 35,
-                                                    "count": 5
-                                                  },
-                                                  {
-                                                    "category": "LANGUAGE",
-                                                    "usageTime": 34,
-                                                    "count": 6
-                                                  },
-                                                  {
-                                                    "category": "ENGLISH",
-                                                    "usageTime": 29,
-                                                    "count": 6
-                                                  },
-                                                  {
-                                                    "category": "HOBBY",
-                                                    "usageTime": 24,
-                                                    "count": 6
-                                                  },
-                                                  {
-                                                    "category": "READING",
-                                                    "usageTime": 16,
-                                                    "count": 5
-                                                  }
-                                                ]
-                                              }
-                                            }
+                                                       "data": {
+                                                         "memberCreateDate": "2023-02-05",
+                                                         "dayAvailableTimes": [
+                                                           {
+                                                             "date": "2025-01-27",
+                                                             "availableTime": 176
+                                                           },
+                                                           {
+                                                             "date": "2025-01-28",
+                                                             "availableTime": 46
+                                                           },
+                                                           {
+                                                             "date": "2025-01-29",
+                                                             "availableTime": 41
+                                                           },
+                                                           {
+                                                             "date": "2025-01-30",
+                                                             "availableTime": 98
+                                                           },
+                                                           {
+                                                             "date": "2025-01-31",
+                                                             "availableTime": 34
+                                                           },
+                                                           {
+                                                             "date": "2025-02-01",
+                                                             "availableTime": 0
+                                                           },
+                                                           {
+                                                             "date": "2025-02-02",
+                                                             "availableTime": 0
+                                                           }
+                                                         ],
+                                                         "totalTodoCount": 32,
+                                                         "lastWeekDiff": -128,
+                                                         "totalAvailableTime": 395,
+                                                         "moodCounts": [
+                                                           {
+                                                             "mood": "MODERATE",
+                                                             "count": 5
+                                                           },
+                                                           {
+                                                             "mood": "SATISFIED",
+                                                             "count": 5
+                                                           }
+                                                         ],
+                                                         "categoryTodoCounts": [
+                                                           {
+                                                             "category": "NEWS",
+                                                             "usageTime": 37,
+                                                             "count": 8
+                                                           },
+                                                           {
+                                                             "category": "OTHERS",
+                                                             "usageTime": 35,
+                                                             "count": 4
+                                                           },
+                                                           {
+                                                             "category": "ENGLISH",
+                                                             "usageTime": 29,
+                                                             "count": 6
+                                                           },
+                                                           {
+                                                             "category": "LANGUAGE",
+                                                             "usageTime": 28,
+                                                             "count": 4
+                                                           },
+                                                           {
+                                                             "category": "HOBBY",
+                                                             "usageTime": 24,
+                                                             "count": 6
+                                                           },
+                                                           {
+                                                             "category": "READING",
+                                                             "usageTime": 15,
+                                                             "count": 4
+                                                           }
+                                                         ]
+                                                       }
+                                                     }
+                                           """
+                                    ),
+                                    @ExampleObject(
+                                            name = "계획은 있으나 한 일이 없는 경우",
+                                            value = """
+                                                    {
+                                                      "data": {
+                                                        "memberCreateDate": "2023-02-05",
+                                                        "dayAvailableTimes": [
+                                                          {
+                                                            "date": "2025-01-31",
+                                                            "availableTime": 34
+                                                          },
+                                                          {
+                                                            "date": "2025-02-01",
+                                                            "availableTime": 0
+                                                          },
+                                                          {
+                                                            "date": "2025-02-02",
+                                                            "availableTime": 0
+                                                          },
+                                                          {
+                                                            "date": "2025-02-03",
+                                                            "availableTime": 0
+                                                          },
+                                                          {
+                                                            "date": "2025-02-04",
+                                                            "availableTime": 0
+                                                          },
+                                                          {
+                                                            "date": "2025-02-05",
+                                                            "availableTime": 0
+                                                          },
+                                                          {
+                                                            "date": "2025-02-06",
+                                                            "availableTime": 0
+                                                          }
+                                                        ],
+                                                        "totalTodoCount": 0,
+                                                        "lastWeekDiff": -470,
+                                                        "totalAvailableTime": 34,
+                                                        "moodCounts": [
+                                                          {
+                                                            "mood": "SATISFIED",
+                                                            "count": 1
+                                                          }
+                                                        ],
+                                                        "categoryTodoCounts": []
+                                                    }
+                                                }
                                             """
                                     ),
                                     @ExampleObject(
                                             name = "주간 통계 데이터가 없는 경우",
                                             value = """
                                             {
+                                                "memberCreateDate": "2023-02-05",
                                                 "data": null
                                             }
                                             """

--- a/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
+++ b/backend/src/main/java/com/dubu/backend/statistic/service/impl/StatisticServiceImpl.java
@@ -47,7 +47,7 @@ public class StatisticServiceImpl implements StatisticService {
         List<Plan> dayPlans = planRepository.findByMemberAndCreatedAtBetween(member, date.atStartOfDay(), date.atTime(LocalTime.MAX));
         List<Path> dayPaths = pathRepository.findByPlansAndTypeAndIsCompleted(dayPlans, TodoType.DONE, true);
 
-        if(dayPlans == null || dayPlans.isEmpty() || dayPaths == null || dayPaths.isEmpty()){
+        if(dayPlans == null || dayPlans.isEmpty()){
             return DayStatisticInfo.of(member.getCreatedAt().toLocalDate());
         }
 
@@ -66,7 +66,7 @@ public class StatisticServiceImpl implements StatisticService {
         List<Todo> completedTodos = todoRepository.findByPathIdsAndTypeAndIsCompleted(pathIdsOfWeekPlans, TodoType.DONE);
 //        List<Path> thisWeekPaths = pathRepository.findByPlansAndTypeAndIsCompleted(thisWeekPlans, TodoType.DONE, true);
 
-        if(thisWeekPlans == null || thisWeekPlans.isEmpty() || pathIdsOfWeekPlans == null || pathIdsOfWeekPlans.isEmpty() || completedTodos == null || completedTodos.isEmpty()){
+        if(thisWeekPlans == null || thisWeekPlans.isEmpty()){
             return WeekStatisticInfo.of(member.getCreatedAt().toLocalDate());
         }
 


### PR DESCRIPTION
## Issue Number

close #205 
## As-Is
<!-- 문제 상황 정의 -->
통계 조회에서 계획이 있지만 한 일이 없는 경우 관련 데이터를 전송하지 않는 문제가 존재한다.

## To-Be
<!-- 변경 사항 -->
- [x] 계획에 조회 쿼리에 isCompleted 필터링 조건 추가
- [x] 계획은 있지만 피드백 데이터가 없는 경우에에도 데이터 전송

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved data retrieval so that only finalized plans are displayed for specified date ranges.
  - Streamlined the logic used to compute daily and weekly statistics.

- **Documentation**
  - Enhanced API documentation with clearer and more comprehensive example scenarios for daily and weekly statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->