### PR TITLE
[REFACTOR] 경로 조회시 사용자 경험 개선을 위한 경로 표시 순서 변경 및 ODsay 장애 상황 발생 시 처리 로직 추가

### DIFF
--- a/backend/src/main/java/com/dubu/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/dubu/backend/notification/application/NotificationService.java
@@ -2,7 +2,9 @@ package com.dubu.backend.notification.application;
 
 
 import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.dto.MemberStatusChangeDto;
 import com.dubu.backend.member.exception.MemberNotFoundException;
+import com.dubu.backend.member.infra.amqp.MemberStatusEventProducer;
 import com.dubu.backend.member.infra.repository.MemberRepository;
 import com.dubu.backend.notification.config.VapidKeyConfig;
 import com.dubu.backend.notification.domain.PushSubscription;
@@ -10,6 +12,7 @@ import com.dubu.backend.notification.dto.PushMessageDto;
 import com.dubu.backend.notification.dto.PushSubscriptionDto;
 import com.dubu.backend.notification.exception.DuplicateSubscriptionException;
 import com.dubu.backend.notification.exception.UnavailablePushServiceException;
+import com.dubu.backend.notification.infra.amqp.PushMessageEventProducer;
 import com.dubu.backend.notification.infra.repository.PushSubscriptionRepository;
 import com.dubu.backend.plan.domain.Plan;
 import com.dubu.backend.plan.exception.PlanNotFoundException;
@@ -37,6 +40,8 @@ public class NotificationService {
     private final MemberRepository memberRepository;
     private final PlanRepository planRepository;
     private final PushSubscriptionRepository subscriptionRepository;
+    private final PushMessageEventProducer pushMessageEventProducer;
+    private final MemberStatusEventProducer memberStatusEventProducer;
     private final ObjectMapper objectMapper;
 
     @Value("${admin.email}")
@@ -103,5 +108,23 @@ public class NotificationService {
                 throw new UnavailablePushServiceException();
             }
         }
+    }
+
+    public void sendPushAndMemberStatusChange(Long memberId, Plan plan) {
+        // 푸시 메시지 이벤트 발행
+        PushMessageDto pushMessageDto = new PushMessageDto(
+                memberId,
+                plan.getId(),
+                "잘 도착하셨나요? 30분 뒤면 오늘 한 일을 체크할 수 없어요😭",
+                "얼른 접속해서 오늘 한 일을 체크하고 피드백을 기록해 보세요~"
+        );
+        pushMessageEventProducer.sendDelayedPush(pushMessageDto);
+
+        // 상태 변경 이벤트 발행
+        MemberStatusChangeDto memberStatusChangeDto = new MemberStatusChangeDto(
+                memberId,
+                plan.getId()
+        );
+        memberStatusEventProducer.send(memberStatusChangeDto);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.Map;
@@ -77,7 +76,27 @@ public interface PlanApi {
             )
     })
     SuccessResponse<Map<String, Long>> createPlan(
-            @Parameter(hidden = true) @RequestAttribute("memberId") Long memberId,
+            Long memberId,
+            @Parameter(
+                    description = "출발지의 X 좌표(경도)",
+                    example = "127.0276009",
+                    required = true
+            ) Double startX,
+            @Parameter(
+                    description = "출발지의 Y 좌표(위도)",
+                    example = "37.4979421",
+                    required = true
+            ) Double startY,
+            @Parameter(
+                    description = "도착지의 X 좌표(경도)",
+                    example = "126.9783740",
+                    required = true
+            ) Double endX,
+            @Parameter(
+                    description = "도착지의 Y 좌표(위도)",
+                    example = "37.5666103",
+                    required = true
+            ) Double endY,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "계획 생성 요청 DTO",
                     required = true,
@@ -86,6 +105,7 @@ public interface PlanApi {
                             examples = {
                                     @ExampleObject(value = """
                                             {
+                                              "totalTime": 50,
                                               "totalSectionTime": 40,
                                               "paths": [
                                                 {

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanController.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanController.java
@@ -22,9 +22,13 @@ public class PlanController implements PlanApi {
     @PostMapping
     public SuccessResponse<Map<String, Long>> createPlan(
             @RequestAttribute("memberId") Long memberId,
+            @RequestParam("startX") Double startX,
+            @RequestParam("startY") Double startY,
+            @RequestParam("endX") Double endX,
+            @RequestParam("endY") Double endY,
             @RequestBody PlanCreateRequest planCreateRequest
     ) {
-        Long planId = planService.savePlan(memberId, planCreateRequest);
+        Long planId = planService.savePlan(memberId, startX, startY, endX, endY, planCreateRequest);
 
         return new SuccessResponse<>(Map.of("planId", planId));
     }

--- a/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/PlanService.java
@@ -2,15 +2,14 @@ package com.dubu.backend.plan.application;
 
 import com.dubu.backend.member.domain.Member;
 import com.dubu.backend.member.domain.enums.Status;
-import com.dubu.backend.member.dto.MemberStatusChangeDto;
 import com.dubu.backend.member.exception.MemberNotFoundException;
-import com.dubu.backend.member.infra.amqp.MemberStatusEventProducer;
 import com.dubu.backend.member.infra.repository.MemberRepository;
-import com.dubu.backend.notification.dto.PushMessageDto;
-import com.dubu.backend.notification.infra.amqp.PushMessageEventProducer;
+import com.dubu.backend.notification.application.NotificationService;
 import com.dubu.backend.plan.domain.Feedback;
 import com.dubu.backend.plan.domain.Path;
 import com.dubu.backend.plan.domain.Plan;
+import com.dubu.backend.plan.domain.Route;
+import com.dubu.backend.plan.domain.vo.PathIdentifier;
 import com.dubu.backend.plan.dto.request.PlanCreateRequest;
 import com.dubu.backend.plan.dto.request.PlanFeedbackCreateRequest;
 import com.dubu.backend.plan.dto.response.FeedbackWritePageInfoResponse;
@@ -39,62 +38,55 @@ import java.util.stream.IntStream;
 @Service
 @RequiredArgsConstructor
 public class PlanService {
+    private final RouteService routeService;
+    private final NotificationService notificationService;
     private final MemberRepository memberRepository;
     private final PlanRepository planRepository;
     private final PathRepository pathRepository;
     private final ScheduleRepository scheduleRepository;
     private final TodoRepository todoRepository;
     private final FeedbackRepository feedbackRepository;
-    private final PushMessageEventProducer pushMessageEventProducer;
-    private final MemberStatusEventProducer memberStatusEventProducer;
 
     @Transactional
-    public Long savePlan(Long memberId, PlanCreateRequest planCreateRequest) {
+    public Long savePlan(
+            Long memberId,
+            Double startX, Double startY,
+            Double endX, Double endY,
+            PlanCreateRequest request
+    ) {
         Member currentMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
+        // STOP인 상태의 유저만 사용 가능
         if (currentMember.getStatus() != Status.STOP) {
             throw new InvalidMemberStatusException(currentMember.getStatus().name());
         }
 
-        Plan newPlan = Plan.createPlan(currentMember, planCreateRequest.totalSectionTime());
-        Plan createdPlan = planRepository.save(newPlan);
-
-        List<Path> paths = IntStream.range(0, planCreateRequest.paths().size())
-                .mapToObj(index -> Path.createPath(newPlan, planCreateRequest.paths().get(index), index))
+        // 새로 만드는 경로가 기존에 저장된 경로인지 체크하기 위한 PathIdentifier 추출
+        List<PathIdentifier> newPathIdentifiers = request.paths().stream()
+                .map(path -> new PathIdentifier(path.trafficType(), path.startName(), path.endName()))
                 .toList();
-        pathRepository.saveAll(paths);
 
-        Schedule schedule = scheduleRepository.findLatestSchedule(currentMember, LocalDate.now())
-                .orElseThrow(() -> new ScheduleNotFoundException());
+        // Route 재사용 여부 확인
+        Route reusableRoute = routeService.findReusableRoute(startX, startY, endX, endY, newPathIdentifiers);
 
-        List<Todo> existingTodos = schedule.getTodos();
-        List<Todo> newTodos = new ArrayList<>();
+        Plan newPlan = Plan.createPlan(currentMember, request.totalSectionTime());
+        planRepository.save(newPlan);
 
-        for (int i = 0; i < existingTodos.size(); i++) {
-            Todo original = existingTodos.get(i);
-            // round-robin으로 Path 할당
-            Path assignedPath = paths.get(i % paths.size());
-            Todo clonedTodo = Todo.copyOf(original, assignedPath);
-
-            newTodos.add(clonedTodo);
+        Route finalRoute = null;
+        if (reusableRoute == null) {
+            finalRoute = routeService.createNewRoute(startX, startY, endX, endY, request.totalTime());
         }
-        todoRepository.saveAll(newTodos);
+
+        // Path 생성 → route는 기존꺼면 null, 새 route 있으면 연결
+        List<Path> paths = createAndSavePaths(newPlan, finalRoute, request);
+
+        // 오늘의 할 일(Todo) Path 할당 & Todo 내용 복제하여 저장
+        assignTodosToPaths(currentMember, paths);
+
         currentMember.updateStatus(Status.MOVE);
 
-        PushMessageDto pushMessageDto = new PushMessageDto(
-                memberId,
-                newPlan.getId(),
-                "잘 도착하셨나요? 30분 뒤면 오늘 한 일을 체크할 수 없어요😭",
-                "얼른 접속해서 오늘 한 일을 체크하고 피드백을 기록해 보세요~"
-        );
-        pushMessageEventProducer.sendDelayedPush(pushMessageDto);
-
-        MemberStatusChangeDto memberStatusChangeDto = new MemberStatusChangeDto(
-                memberId,
-                createdPlan.getId()
-        );
-        memberStatusEventProducer.send(memberStatusChangeDto);
+        notificationService.sendPushAndMemberStatusChange(memberId, newPlan);
 
         return newPlan.getId();
     }
@@ -128,7 +120,7 @@ public class PlanService {
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
         Plan recentPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
-                .orElseThrow(() -> new PlanNotFoundException());
+                .orElseThrow(PlanNotFoundException::new);
 
         List<Path> paths = pathRepository.findByPlanWithTodosOrderByPathOrder(recentPlan);
 
@@ -145,7 +137,7 @@ public class PlanService {
         }
 
         Plan recentPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
-                .orElseThrow(() -> new PlanNotFoundException());
+                .orElseThrow(PlanNotFoundException::new);
 
         return FeedbackWritePageInfoResponse.of(recentPlan);
     }
@@ -160,7 +152,7 @@ public class PlanService {
         }
 
         Plan recentPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(memberId)
-                .orElseThrow(() -> new PlanNotFoundException());
+                .orElseThrow(PlanNotFoundException::new);
 
         recentPlan.getPaths().forEach(path -> {
             List<Todo> todos = path.getTodos();
@@ -197,5 +189,42 @@ public class PlanService {
         currentMember.updateStatus(Status.STOP);
 
         planRepository.delete(planToDelete);
+    }
+
+    /**
+     * Path 생성 및 저장
+     */
+    private List<Path> createAndSavePaths(Plan plan, Route route, PlanCreateRequest request) {
+        // pathOrder = index
+        List<Path> paths = IntStream.range(0, request.paths().size())
+                .mapToObj(i -> Path.createPath(
+                        plan,
+                        route, // null or 새로 생성한 route
+                        request.paths().get(i),
+                        i
+                ))
+                .toList();
+
+        pathRepository.saveAll(paths);
+        return paths;
+    }
+
+    /**
+     * Schedule에서 Todo를 가져와 Round-Robin으로 새로 생성한 Paths에 할당
+     */
+    private void assignTodosToPaths(Member member, List<Path> paths) {
+        Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now())
+                .orElseThrow(ScheduleNotFoundException::new);
+
+        List<Todo> existingTodos = schedule.getTodos();
+        List<Todo> newTodos = new ArrayList<>();
+
+        for (int i = 0; i < existingTodos.size(); i++) {
+            Todo original = existingTodos.get(i);
+            Path assignedPath = paths.get(i % paths.size());
+            Todo cloned = Todo.copyOf(original, assignedPath);
+            newTodos.add(cloned);
+        }
+        todoRepository.saveAll(newTodos);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
@@ -36,6 +36,15 @@ public class RouteService {
     private final RouteRepository routeRepository;
     private final PathRepository pathRepository;
 
+    @Transactional
+    public Route createNewRoute(Double startX, Double startY,
+                                Double endX, Double endY,
+                                Integer totalTime
+    ) {
+        Route newRoute = Route.createRoute(startX, startY, endX, endY, totalTime);
+        return routeRepository.save(newRoute);
+    }
+
     /**
      * 출발지, 도착지 좌표로 경로를 조회하여,
      * DB 또는 ODsay API 결과에 따라 RouteSearchResponse DTO 목록을 반환합니다.
@@ -76,6 +85,30 @@ public class RouteService {
         );
 
         return response;
+    }
+
+    @Transactional(readOnly = true)
+    public Route findReusableRoute(Double startX, Double startY, Double endX, Double endY,
+                                   List<PathIdentifier> newPathIdentifiers) {
+
+        // 좌표가 같은 Route들 모두 조회
+        List<Route> existingRoutes = routeRepository.findAllWithPathsByCoordinates(startX, startY, endX, endY);
+
+        // 각 Route의 PathIdentifier 목록 추출 후, newPathIdentifiers를 포함하는지 검사
+        return existingRoutes.stream()
+                .filter(routeCandidate -> {
+                    List<PathIdentifier> existingPathIdentifiers = routeCandidate.getPaths().stream()
+                            .map(p -> new PathIdentifier(
+                                    p.getTrafficType().name(),
+                                    p.getStartName(),
+                                    p.getEndName()
+                            ))
+                            .distinct()
+                            .toList();
+                    return existingPathIdentifiers.containsAll(newPathIdentifiers);
+                })
+                .findFirst()
+                .orElse(null);
     }
 
     private List<PathIdentifier> loadRecentlyUsedRoute(Long memberId) {

--- a/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
@@ -4,18 +4,22 @@ import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.MemberRepository;
 import com.dubu.backend.plan.domain.Path;
 import com.dubu.backend.plan.domain.Plan;
+import com.dubu.backend.plan.domain.Route;
 import com.dubu.backend.plan.domain.vo.PathIdentifier;
 import com.dubu.backend.plan.dto.response.OdsayRouteApiResponse;
 import com.dubu.backend.plan.dto.response.RouteSearchResponse;
 import com.dubu.backend.plan.infra.client.OdsayApiClient;
 import com.dubu.backend.plan.infra.repository.PathRepository;
 import com.dubu.backend.plan.infra.repository.PlanRepository;
+import com.dubu.backend.plan.infra.repository.RouteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -24,6 +28,7 @@ public class RouteService {
     private final OdsayApiClient odsayApiClient;
     private final MemberRepository memberRepository;
     private final PlanRepository planRepository;
+    private final RouteRepository routeRepository;
     private final PathRepository pathRepository;
 
     /**
@@ -41,11 +46,27 @@ public class RouteService {
         OdsayRouteApiResponse odsayRouteApiResponse = odsayApiClient.searchPublicTransportRoute(startX, startY, endX, endY);
 
         List<RouteSearchResponse> response = new ArrayList<>();
-        for (OdsayRouteApiResponse.Path apiPath : odsayRouteApiResponse.result().path()) {
-            boolean isRecentlyUsed = isSameAsRecentlyUsedRoute(apiPath, recentlyUsedRoute);
-            RouteSearchResponse routeDto = convertApiPathToRoute(apiPath, isRecentlyUsed);
-            response.add(routeDto);
+        if (odsayRouteApiResponse == null || odsayRouteApiResponse.result() == null || odsayRouteApiResponse.result().path() == null) {
+            Optional<Route> optionalRoute = routeRepository.findRouteWithPathsByCoordinates(startX, startY, endX, endY);
+
+            if (optionalRoute.isPresent()) {
+                Route route = optionalRoute.get();
+                boolean isRecentlyUsed = false;
+                RouteSearchResponse dto = RouteSearchResponse.fromRoute(route, isRecentlyUsed);
+                response.add(dto);
+            }
+        } else {
+            for (OdsayRouteApiResponse.Path apiPath : odsayRouteApiResponse.result().path()) {
+                boolean isRecentlyUsed = isSameAsRecentlyUsedRoute(apiPath, recentlyUsedRoute);
+                RouteSearchResponse routeDto = convertApiPathToRoute(apiPath, isRecentlyUsed);
+                response.add(routeDto);
+            }
         }
+
+        response.sort(Comparator
+                .comparing(RouteSearchResponse::isRecentlyUsed, Comparator.reverseOrder())
+                .thenComparing(RouteSearchResponse::totalTime)
+        );
 
         return response;
     }
@@ -115,11 +136,11 @@ public class RouteService {
         int totalTime = info.totalTime();
         int totalSectionTime = 0;
 
-        List<RouteSearchResponse.Path> pathDtoList = new ArrayList<>();
+        List<RouteSearchResponse.PathDto> pathDtoList = new ArrayList<>();
 
         // SubPath(=ODsay) → Path(=두리번)Dto 변환
         for (OdsayRouteApiResponse.SubPath subPath : apiPath.subPath()) {
-            RouteSearchResponse.Path dtoPath = convertApiSubPathToPathDto(subPath);
+            RouteSearchResponse.PathDto dtoPath = convertApiSubPathToPathDto(subPath);
 
             if ("BUS".equals(dtoPath.trafficType()) || "SUBWAY".equals(dtoPath.trafficType())) {
                 totalSectionTime += dtoPath.sectionTime();
@@ -130,7 +151,7 @@ public class RouteService {
         return new RouteSearchResponse(isRecentlyUsed, totalTime, totalSectionTime, pathDtoList);
     }
 
-    private RouteSearchResponse.Path convertApiSubPathToPathDto(OdsayRouteApiResponse.SubPath subPath) {
+    private RouteSearchResponse.PathDto convertApiSubPathToPathDto(OdsayRouteApiResponse.SubPath subPath) {
         int tType = subPath.trafficType();
         String trafficType = switch (tType) {
             case 1 -> "SUBWAY";
@@ -139,7 +160,6 @@ public class RouteService {
             default -> "UNKNOWN";
         };
 
-        String subwayName = null;
         Integer subwayCode = null;
         String busNumber = null;
         Integer busType = null;
@@ -149,7 +169,6 @@ public class RouteService {
         if (subPath.lane() != null && !subPath.lane().isEmpty()) {
             OdsayRouteApiResponse.Lane lane = subPath.lane().get(0);
             if ("SUBWAY".equals(trafficType)) {
-                subwayName = lane.name();
                 subwayCode = lane.subwayCode();
                 startName = subPath.startName() + "역";
                 endName = subPath.endName() + "역";
@@ -161,10 +180,9 @@ public class RouteService {
             }
         }
 
-        return new RouteSearchResponse.Path(
+        return new RouteSearchResponse.PathDto(
                 trafficType,
                 subPath.sectionTime(),
-                subwayName,
                 subwayCode,
                 busNumber,
                 busType,

--- a/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
+++ b/backend/src/main/java/com/dubu/backend/plan/application/RouteService.java
@@ -19,10 +19,15 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 
+/**
+ * 같은 의미인 명칭 정리
+ * 두리번 사용 = ODsay 사용
+ * Route = Path
+ * Path = SubPath
+ */
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class RouteService {
     private final OdsayApiClient odsayApiClient;
@@ -32,37 +37,39 @@ public class RouteService {
     private final PathRepository pathRepository;
 
     /**
-     * 같은 의미인 명칭 정리
-     * 두리번 사용 = ODsay 사용
-     * Route = Path
-     * Path = SubPath
+     * 출발지, 도착지 좌표로 경로를 조회하여,
+     * DB 또는 ODsay API 결과에 따라 RouteSearchResponse DTO 목록을 반환합니다.
      */
+    @Transactional(readOnly = true)
     public List<RouteSearchResponse> getRoutesByStartAndDestination(Long memberId, Double startX, Double startY, Double endX, Double endY) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
+        // 사용자가 최근 이용한 경로 조회
         List<PathIdentifier> recentlyUsedRoute = loadRecentlyUsedRoute(memberId);
 
         OdsayRouteApiResponse odsayRouteApiResponse = odsayApiClient.searchPublicTransportRoute(startX, startY, endX, endY);
 
         List<RouteSearchResponse> response = new ArrayList<>();
         if (odsayRouteApiResponse == null || odsayRouteApiResponse.result() == null || odsayRouteApiResponse.result().path() == null) {
-            Optional<Route> optionalRoute = routeRepository.findRouteWithPathsByCoordinates(startX, startY, endX, endY);
-
-            if (optionalRoute.isPresent()) {
-                Route route = optionalRoute.get();
-                boolean isRecentlyUsed = false;
+            // API 결과가 없는 경우, DB에서 좌표에 해당하는 Route를 조회 (경로와 관련된 Path도 함께 로딩)
+            List<Route> routeList = routeRepository.findAllWithPathsByCoordinates(startX, startY, endX, endY);
+            routeList.forEach(route -> {
+                // DB에 저장된 경로와 최근 사용 경로가 동일한지 확인
+                boolean isRecentlyUsed = isSameAsSavedRoute(route, recentlyUsedRoute);
                 RouteSearchResponse dto = RouteSearchResponse.fromRoute(route, isRecentlyUsed);
                 response.add(dto);
-            }
+            });
         } else {
             for (OdsayRouteApiResponse.Path apiPath : odsayRouteApiResponse.result().path()) {
+                // API에서 받은 경로와 최근 사용 경로가 동일한지 확인
                 boolean isRecentlyUsed = isSameAsRecentlyUsedRoute(apiPath, recentlyUsedRoute);
                 RouteSearchResponse routeDto = convertApiPathToRoute(apiPath, isRecentlyUsed);
                 response.add(routeDto);
             }
         }
 
+        // 최근 사용 여부 내림차순, 그 다음 totalTime 오름차순 정렬
         response.sort(Comparator
                 .comparing(RouteSearchResponse::isRecentlyUsed, Comparator.reverseOrder())
                 .thenComparing(RouteSearchResponse::totalTime)
@@ -95,21 +102,51 @@ public class RouteService {
                 .toList();
     }
 
+    /**
+     * DB에서 조회한 Route와 최근 사용 Route가 동일한지 확인
+     */
+    private boolean isSameAsSavedRoute(Route route, List<PathIdentifier> recentlyUsedRoute) {
+        List<PathIdentifier> routePathIdentifiers = route.getPaths().stream()
+                .sorted(Comparator.comparing(Path::getPathOrder)) // pathOrder 기준 정렬
+                .map(p -> new PathIdentifier(
+                        p.getTrafficType().name(), // Enum -> String
+                        p.getStartName(),
+                        p.getEndName()
+                ))
+                .toList();
+
+        return isSameRoute(routePathIdentifiers, recentlyUsedRoute);
+    }
+
+    /**
+     * API 응답을 변환한 Route와 최근 사용 Route가 동일한지 확인
+     */
     private boolean isSameAsRecentlyUsedRoute(OdsayRouteApiResponse.Path apiPath,
                                               List<PathIdentifier> recentlyUsedRoute) {
         List<PathIdentifier> currentRouteKeys = extractRouteKeys(apiPath);
+        return isSameRoute(currentRouteKeys, recentlyUsedRoute);
+    }
 
-        if (currentRouteKeys.size() != recentlyUsedRoute.size()) {
+    /**
+     * 두 개의 PathIdentifier 리스트가 동일한지 비교
+     * (길이가 다르면 false, 순서대로 하나씩 비교)
+     */
+    private boolean isSameRoute(List<PathIdentifier> routePathIdentifiers, List<PathIdentifier> recentlyUsedRoute) {
+        if (routePathIdentifiers.size() != recentlyUsedRoute.size()) {
             return false;
         }
-        for (int i = 0; i < currentRouteKeys.size(); i++) {
-            if (!currentRouteKeys.get(i).equals(recentlyUsedRoute.get(i))) {
+        for (int i = 0; i < routePathIdentifiers.size(); i++) {
+            if (!routePathIdentifiers.get(i).equals(recentlyUsedRoute.get(i))) {
                 return false;
             }
         }
         return true;
     }
 
+    /**
+     * ODsay API 경로(apiPath)에서 각 SubPath의 (trafficType, startName, endName) 정보를 추출
+     * 지하철의 경우 "역"을 붙여서 반환(서울역 제외)
+     */
     private List<PathIdentifier> extractRouteKeys(OdsayRouteApiResponse.Path apiPath) {
         List<PathIdentifier> result = new ArrayList<>();
         for (OdsayRouteApiResponse.SubPath subPath : apiPath.subPath()) {
@@ -120,15 +157,14 @@ public class RouteService {
                 String startName = subPath.startName();
                 String endName = subPath.endName();
                 if (tType == 1) { // 지하철
-                    startName += "역";
-                    endName += "역";
+                    startName = Objects.equals(subPath.startName(), "서울역") ? subPath.startName() : subPath.startName() + "역";
+                    endName = Objects.equals(subPath.endName(), "서울역") ? subPath.endName() : subPath.endName() + "역";
                 }
                 result.add(new PathIdentifier(trafficType, startName, endName));
             }
         }
         return result;
     }
-
 
     private RouteSearchResponse convertApiPathToRoute(OdsayRouteApiResponse.Path apiPath, boolean isRecentlyUsed) {
         OdsayRouteApiResponse.Info info = apiPath.info();
@@ -170,8 +206,8 @@ public class RouteService {
             OdsayRouteApiResponse.Lane lane = subPath.lane().get(0);
             if ("SUBWAY".equals(trafficType)) {
                 subwayCode = lane.subwayCode();
-                startName = subPath.startName() + "역";
-                endName = subPath.endName() + "역";
+                startName = Objects.equals(subPath.startName(), "서울역") ? subPath.startName() : subPath.startName() + "역";
+                endName = Objects.equals(subPath.endName(), "서울역") ? subPath.endName() : subPath.endName() + "역";
             } else if ("BUS".equals(trafficType)) {
                 busNumber = lane.busNo();
                 busType = lane.type();

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
@@ -63,9 +63,10 @@ public class Path extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "SMALLINT")
     private Integer pathOrder;
 
-    public static Path createPath(Plan plan, PlanCreateRequest.Path pathRequest, int pathOrder) {
+    public static Path createPath(Plan plan, Route route, PlanCreateRequest.Path pathRequest, int pathOrder) {
         return Path.builder()
                 .plan(plan)
+                .route(route)
                 .trafficType(TrafficType.from(pathRequest.trafficType()))
                 .subwayCode(pathRequest.subwayCode())
                 .busNumber(pathRequest.busNumber())

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Path.java
@@ -16,7 +16,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"plan_id", "pathOrder"})
+        @UniqueConstraint(columnNames = {"plan_id", "pathOrder"}),
+        @UniqueConstraint(columnNames = {"route_id", "pathOrder"})
 })
 public class Path extends BaseTimeEntity {
     @Id
@@ -25,8 +26,12 @@ public class Path extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "plan_id", nullable = false)
+    @JoinColumn(name = "plan_id")
     private Plan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "route_id")
+    private Route route;
 
 //    @BatchSize(size = 100)
     @Builder.Default

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Route.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Route.java
@@ -31,4 +31,14 @@ public class Route extends BaseTimeEntity {
     private Double endX;
 
     private Double endY;
+
+    public static Route createRoute(Double startX, Double startY, Double endX, Double endY, Integer totalTime) {
+        return Route.builder()
+                .startX(startX)
+                .startY(startY)
+                .endX(endX)
+                .endY(endY)
+                .totalTime(totalTime)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/dubu/backend/plan/domain/Route.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/Route.java
@@ -1,0 +1,34 @@
+package com.dubu.backend.plan.domain;
+
+import com.dubu.backend.global.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Route extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "route_id")
+    private Long id;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "route", cascade = CascadeType.REMOVE)
+    private List<Path> paths = new ArrayList<>();
+
+    private Integer totalTime;
+
+    private Double startX;
+
+    private Double startY;
+
+    private Double endX;
+
+    private Double endY;
+}

--- a/backend/src/main/java/com/dubu/backend/plan/domain/enums/TrafficType.java
+++ b/backend/src/main/java/com/dubu/backend/plan/domain/enums/TrafficType.java
@@ -5,7 +5,7 @@ import com.dubu.backend.plan.exception.InvalidTrafficTypeException;
 import java.util.Arrays;
 
 public enum TrafficType {
-    SUBWAY, BUS;
+    SUBWAY, BUS, WALK;
 
     public static TrafficType from(String value) {
         return Arrays.stream(TrafficType.values())

--- a/backend/src/main/java/com/dubu/backend/plan/dto/request/PlanCreateRequest.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/request/PlanCreateRequest.java
@@ -3,6 +3,7 @@ package com.dubu.backend.plan.dto.request;
 import java.util.List;
 
 public record PlanCreateRequest(
+        Integer totalTime,
         Integer totalSectionTime,
         List<PlanCreateRequest.Path> paths
 ) {

--- a/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/response/PlanRecentResponse.java
@@ -2,6 +2,7 @@ package com.dubu.backend.plan.dto.response;
 
 import com.dubu.backend.plan.domain.Path;
 import com.dubu.backend.plan.domain.Plan;
+import com.dubu.backend.plan.domain.enums.TrafficType;
 import com.dubu.backend.todo.entity.Todo;
 
 import java.time.LocalDateTime;
@@ -18,7 +19,10 @@ public record PlanRecentResponse(
                 plan.getId(),
                 plan.getTotalTime(),
                 plan.getCreatedAt(),
-                paths.stream().map(PlanPathResponse::from).toList()
+                paths.stream()
+                        .filter(path -> path.getTrafficType() != TrafficType.WALK)
+                        .map(PlanPathResponse::from)
+                        .toList()
         );
     }
 

--- a/backend/src/main/java/com/dubu/backend/plan/dto/response/RouteSearchResponse.java
+++ b/backend/src/main/java/com/dubu/backend/plan/dto/response/RouteSearchResponse.java
@@ -1,22 +1,50 @@
 package com.dubu.backend.plan.dto.response;
 
+import com.dubu.backend.plan.domain.Path;
+import com.dubu.backend.plan.domain.Route;
+import com.dubu.backend.plan.domain.enums.TrafficType;
+
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record RouteSearchResponse(
         Boolean isRecentlyUsed,
         Integer totalTime,
         Integer totalSectionTime,
-        List<Path> paths
+        List<PathDto> paths
 ) {
-    public record Path(
+    public record PathDto(
             String trafficType,
             Integer sectionTime,
-            String subwayName,
             Integer subwayCode,
             String busNumber,
             Integer busType,
             String startName,
             String endName
     ) {
+    }
+
+    public static RouteSearchResponse fromRoute(Route route, boolean isRecentlyUsed) {
+        int totalSectionTime = route.getPaths().stream()
+                .filter(path -> path.getTrafficType() != TrafficType.WALK)
+                .mapToInt(Path::getSectionTime)
+                .sum();
+
+        // 각 Path 엔티티를 DTO로 변환 (pathOrder 기준 정렬)
+        List<PathDto> pathDtoList = route.getPaths().stream()
+                .sorted(Comparator.comparing(Path::getPathOrder))
+                .map(p -> new PathDto(
+                        p.getTrafficType().name(),
+                        p.getSectionTime(),
+                        p.getSubwayCode(),
+                        p.getBusNumber(),
+                        p.getBusType(),
+                        p.getStartName(),
+                        p.getEndName()
+                ))
+                .collect(Collectors.toList());
+
+        return new RouteSearchResponse(isRecentlyUsed, route.getTotalTime(), totalSectionTime, pathDtoList);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/RouteRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/RouteRepository.java
@@ -1,0 +1,26 @@
+package com.dubu.backend.plan.infra.repository;
+
+import com.dubu.backend.plan.domain.Route;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface RouteRepository extends JpaRepository<Route, Long> {
+    @Query("""
+        select r
+        from Route r
+            left join fetch r.paths p
+        where r.startX = :startX
+          and r.startY = :startY
+          and r.endX = :endX
+          and r.endY = :endY
+    """)
+    Optional<Route> findRouteWithPathsByCoordinates(
+            @Param("startX") Double startX,
+            @Param("startY") Double startY,
+            @Param("endX") Double endX,
+            @Param("endY") Double endY
+    );
+}

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/RouteRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/RouteRepository.java
@@ -5,19 +5,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
     @Query("""
         select r
         from Route r
-            left join fetch r.paths p
+            left join fetch r.paths
         where r.startX = :startX
           and r.startY = :startY
           and r.endX = :endX
           and r.endY = :endY
     """)
-    Optional<Route> findRouteWithPathsByCoordinates(
+    List<Route> findAllWithPathsByCoordinates(
             @Param("startX") Double startX,
             @Param("startY") Double startY,
             @Param("endX") Double endX,


### PR DESCRIPTION
## Issue Number
#201 

## As-Is
<!-- 문제 상황 정의 -->
경로 조회시 사용자 경험 개선을 위한 경로 표시 순서 변경합니다.

## To-Be
<!-- 변경 사항 -->
- [x] 경로 조회 시 사용자가 최근 이용한 경로가 가장 위로 오도록
- [x] 나머지 경로들은 총 이동시간 기준 오름차순 정렬
- [x] ODsay API 사용 불가시 기존에 유저들이 사용한 경로들을 탐색하여 대체 제공
- [x] Plan 저장 시에 현재 선택한 경로가 DB에 저장된 Route가 아니라면 추가

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description
