### PR TITLE
[FIX] 사용성 개선을 위한 정책 변경으로 오늘/내일 할 일관련 기능 수정

### DIFF
--- a/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/entity/Todo.java
@@ -74,6 +74,19 @@ public class Todo extends BaseTimeEntity {
                 .build();
     }
 
+    public static Todo copyOf(Todo originalTodo, Member member, Schedule schedule){
+        return Todo.builder()
+                .member(member)
+                .title(originalTodo.getTitle())
+                .category(originalTodo.getCategory())
+                .difficulty(originalTodo.getDifficulty())
+                .memo(originalTodo.getMemo())
+                .type(TodoType.SCHEDULED)
+                .parentTodo(originalTodo)
+                .schedule(schedule)
+                .build();
+    }
+
     public static Todo copyOf(Todo originalTodo, Path assignedPath) {
         return Todo.builder()
                 .title(originalTodo.getTitle())

--- a/backend/src/main/java/com/dubu/backend/todo/repository/TodoRepository.java
+++ b/backend/src/main/java/com/dubu/backend/todo/repository/TodoRepository.java
@@ -18,6 +18,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long>, CustomTodoRep
     @Query("SELECT t FROM Todo t JOIN FETCH t.category c WHERE t.id = :todoId")
     Optional<Todo> findWithCategoryById(@Param("todoId") Long todoId);
 
+    @Query("SELECT t FROM Todo t JOIN FETCH t.category WHERE t.id IN :todoIds")
+    List<Todo> findTodosWithCategoryByIds(List<Long> todoIds);
+
     // 스케줄, 날짜로 조회
     @Query("SELECT t FROM Todo t JOIN FETCH t.category WHERE t.schedule = :schedule")
     List<Todo> findTodosWithCategoryBySchedule(@Param("schedule")Schedule schedule);

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoManagementService.java
@@ -44,8 +44,8 @@ public class TodayTodoManagementService implements TodoManagementService {
         Category category = categoryRepository.findByName(todoCreateRequest.category()).orElseThrow(() -> new CategoryNotFoundException(todoCreateRequest.category()));
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
 
-        if(schedule.getTodos().size() == 3){
-            throw new TodoLimitExceededException("오늘", 3);
+        if(schedule.getTodos().size() >= 5){
+            throw new TodoLimitExceededException("오늘", 5);
         }
 
         Todo todo = todoCreateRequest.toEntity(member, category, schedule, null, TodoType.SCHEDULED);
@@ -64,8 +64,8 @@ public class TodayTodoManagementService implements TodoManagementService {
 
         Schedule schedule = scheduleRepository.findLatestSchedule(member, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
 
-        if(schedule.getTodos().size() == 3){
-            throw new TodoLimitExceededException("오늘" , 3);
+        if(schedule.getTodos().size() >= 5){
+            throw new TodoLimitExceededException("오늘" , 5);
         }
         Todo parentTodo = todoRepository.findWithCategoryById(todoCreateRequest.todoId()).orElseThrow(() -> new TodoNotFoundException(identifier.todoId()));
 

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoQueryService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TodayTodoQueryService.java
@@ -61,24 +61,13 @@ public class TodayTodoQueryService implements TargetTodoQueryService {
                 throw new MemberCategoryNotFoundException(identifier.memberId());
             }
             List<Long> recommendTodoIds = todoRepository.findTodosWithCategoryByCategoryIdsAndType(categoryIds, TodoType.RECOMMEND);
-
-            Long recommendTodoId = todoRandomSelector.selectOne(recommendTodoIds);
-            Todo recommendTodo = todoRepository.findById(recommendTodoId).get();
+            List<Long> selectedTodoIds = todoRandomSelector.selectTodos(3, recommendTodoIds);
+            List<Todo> selectedTodos = todoRepository.findTodosWithCategoryByIds(selectedTodoIds);
 
             Schedule savedSchedule = scheduleRepository.save(newSchedule);
 
-            Todo newTodo = Todo.of(
-                    recommendTodo.getTitle(),
-                    TodoType.SCHEDULED,
-                    recommendTodo.getDifficulty(),
-                    null,
-                    member,
-                    recommendTodo.getCategory(),
-                    recommendTodo,
-                    newSchedule,
-                    null
-            );
-            todoRepository.save(newTodo);
+            selectedTodos
+                    .forEach(t -> todoRepository.save(Todo.copyOf(t, member, savedSchedule)));
 
             return savedSchedule;
         });

--- a/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoManagementService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/service/impl/TomorrowTodoManagementService.java
@@ -52,8 +52,8 @@ public class TomorrowTodoManagementService implements TodoManagementService {
         List<Todo> tomorrowTodos = null;
 
         // 할 일 3개 이미 존재
-        if(todos.size() == 3){
-            throw new TodoLimitExceededException("내일", 3);
+        if(todos.size() >= 5){
+            throw new TodoLimitExceededException("내일", 5);
         }
 
         // 내일 스케줄이 없는 경우
@@ -87,8 +87,8 @@ public class TomorrowTodoManagementService implements TodoManagementService {
         List<Todo> tomorrowTodos = null;
 
         // 할 일 3개 이미 존재
-        if(todos.size() == 3){
-            throw new TodoLimitExceededException("내일", 3);
+        if(todos.size() >= 5){
+            throw new TodoLimitExceededException("내일", 5);
         }
 
         // 내일 스케줄이 없는 경우

--- a/backend/src/main/java/com/dubu/backend/todo/support/TodoRandomSelector.java
+++ b/backend/src/main/java/com/dubu/backend/todo/support/TodoRandomSelector.java
@@ -9,11 +9,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @Component
 public class TodoRandomSelector {
-
-    public Long selectOne(List<Long> todoIds) {
-        return todoIds.get(ThreadLocalRandom.current().nextInt(todoIds.size()));
-    }
-
     public List<Long> selectTodos(int num, List<Long> todoIds) {
         if (num > todoIds.size()) {
             throw new NotEnoughRecommendedTodosException();


### PR DESCRIPTION
## Issue Number
close #216 
## As-Is
<!-- 문제 상황 정의 -->
오늘 할 일/ 내일 할 일 최대 5개까지 생성하게 변경한다.
회원 최초 진입 시 할 일 추천을 1개 -> 3개로 변경한다.

## To-Be
<!-- 변경 사항 -->
- [x] 오늘 할 일/ 내일 할 일 생성 제한을 5개로 늘린다.
- [x] 회원 최초 진입 시 추천 할 일 리스트에서 생성하는 할 일의 수를 3개 늘린다.
- [x] 추천 할 일 조회 시 풀 테이블 스캔으로 인한 쿼리 요청 시간이 길어지는 문제가 발생하여 category_id, type 에 복합 인덱스를 걸어 해결한다.

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased task limits: Users can now schedule up to 5 tasks, offering more flexibility in planning.
	- Enhanced recommendations: Multiple task suggestions are provided for a more robust planning experience.
	- Streamlined task duplication: Task copying now efficiently replicates key details for easier reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->