### PR TITLE
[FIX] 지도(공유) 페이지에서 주변 사용자 할 일 조회 시 보여줄 데이터 변경 

### DIFF
--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PathRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PathRepository.java
@@ -19,6 +19,9 @@ public interface PathRepository extends JpaRepository<Path, Long>, CustomPathRep
     @Query("SELECT p FROM Path p JOIN FETCH p.todos t WHERE p.plan = :plan AND t.type = :type")
     List<Path> findByPlanAndType(Plan plan, TodoType type);
 
+    @Query("SELECT p FROM Path p JOIN FETCH p.todos t WHERE p.plan = :plan AND t.isCompleted = :isCompleted")
+    List<Path> findPathsByPlanAndIsCompleted(Plan plan, boolean isCompleted);
+
     @Query("SELECT pa.id FROM Path pa join pa.plan pl WHERE pl.member = :member AND pl.createdAt BETWEEN :startTime AND :endTime")
     List<Long> findPathIdsByMemberAndCreatedAtBetween(Member member, LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
+++ b/backend/src/main/java/com/dubu/backend/plan/infra/repository/PlanRepository.java
@@ -13,7 +13,10 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     @Query("SELECT p FROM Plan p LEFT JOIN FETCH p.feedback WHERE p.member.id = :memberId ORDER BY p.createdAt DESC LIMIT 1")
     Optional<Plan> findTopByMemberIdOrderByCreatedAtDesc(Long memberId);
 
-    @Query("SELECT p FROM Plan p JOIN FETCH p.feedback WHERE p.member = :member AND p.isCompleted = true AND p.createdAt between :startTime AND :endTime")
+    @Query("SELECT p FROM Plan p LEFT JOIN FETCH p.feedback WHERE p.member= :member AND p.isCompleted = :isCompleted ORDER BY p.createdAt DESC LIMIT 1")
+    Optional<Plan> findTopByMemberAndIsCompletedOrderByCreatedAtDesc(Member member, boolean isCompleted);
+
+    @Query("SELECT p FROM Plan p JOIN FETCH p.feedback WHERE p.member = :member AND p.createdAt between :startTime AND :endTime")
     List<Plan> findByMemberAndCreatedAtBetween(Member member, LocalDateTime startTime, LocalDateTime endTime);
 
     @Query("SELECT p FROM Plan p JOIN FETCH p.feedback JOIN FETCH p.paths WHERE p.member = :member AND p.isCompleted = true AND p.createdAt between :startTime AND :endTime")

--- a/backend/src/main/java/com/dubu/backend/todo/application/impl/share/ShareServiceImpl.java
+++ b/backend/src/main/java/com/dubu/backend/todo/application/impl/share/ShareServiceImpl.java
@@ -1,7 +1,6 @@
 package com.dubu.backend.todo.application.impl.share;
 
 import com.dubu.backend.member.domain.Member;
-import com.dubu.backend.member.domain.enums.Status;
 import com.dubu.backend.member.dto.MemberLocationDto;
 import com.dubu.backend.member.exception.MemberNotFoundException;
 import com.dubu.backend.member.infra.repository.LocationRedisRepository;
@@ -17,10 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -44,13 +40,9 @@ public class ShareServiceImpl implements ShareService {
 
         List<Member> neighborhoodMembers = memberRepository.findMembersByMemberIds(extractMemberIds(memberLocationInfos));
 
-        List<MemberCategoryInfo> memberCategoryInfosForStopMembers = todoRepository.findTodoCountGroupByCategoryForStopMembers(splitStopMember(neighborhoodMembers), LocalDate.now());
-        List<MemberCategoryInfo> memberCategoryInfosForMoveOrFeedbackMembers = todoRepository.findTodoCountGroupByCategoryForMoveOrFeedbackMembers(splitInMoveOrFeedbackMember(neighborhoodMembers));
+        List<MemberCategoryInfo> memberCategoryInfos = todoRepository.findTodoCountGroupByCategory(neighborhoodMembers);
 
-        MemberCategoryCollection memberCategoryCollection = new MemberCategoryCollection(Stream.concat(
-                memberCategoryInfosForStopMembers.stream(),
-                memberCategoryInfosForMoveOrFeedbackMembers.stream()
-        ).collect(Collectors.toList()));
+        MemberCategoryCollection memberCategoryCollection = new MemberCategoryCollection(memberCategoryInfos);
 
         locationRedisRepository.saveMemberLocation(memberId, new MemberLocationDto(request.x_coordinate(), request.y_coordinate()));
 
@@ -60,16 +52,6 @@ public class ShareServiceImpl implements ShareService {
     private List<Long> extractMemberIds(List<MemberLocationInfo> memberLocationInfos) {
         return memberLocationInfos.stream()
                 .map(MemberLocationInfo::memberId)
-                .toList();
-    }
-
-    private List<Member> splitStopMember(List<Member> members){
-        return members.stream().filter(m -> m.getStatus().equals(Status.STOP)).toList();
-    }
-
-    private List<Member> splitInMoveOrFeedbackMember(List<Member> members) {
-        return members.stream()
-                .filter(m -> m.getStatus().equals(Status.MOVE) || m.getStatus().equals(Status.FEEDBACK))
                 .toList();
     }
 }

--- a/backend/src/main/java/com/dubu/backend/todo/application/impl/share/ShareServiceImpl.java
+++ b/backend/src/main/java/com/dubu/backend/todo/application/impl/share/ShareServiceImpl.java
@@ -38,9 +38,7 @@ public class ShareServiceImpl implements ShareService {
             return null;
         }
 
-        List<Member> neighborhoodMembers = memberRepository.findMembersByMemberIds(extractMemberIds(memberLocationInfos));
-
-        List<MemberCategoryInfo> memberCategoryInfos = todoRepository.findTodoCountGroupByCategory(neighborhoodMembers);
+        List<MemberCategoryInfo> memberCategoryInfos = todoRepository.findTodoCountGroupByCategory(extractMemberIds(memberLocationInfos));
 
         MemberCategoryCollection memberCategoryCollection = new MemberCategoryCollection(memberCategoryInfos);
 

--- a/backend/src/main/java/com/dubu/backend/todo/application/impl/share/ShareTodoService.java
+++ b/backend/src/main/java/com/dubu/backend/todo/application/impl/share/ShareTodoService.java
@@ -48,24 +48,13 @@ public class ShareTodoService {
             throw new InvalidMemberStatusException(surroundingMemberStatus.name());
         }
 
-        List<Todo> surroundMemberTodos = null;
+        Plan latestPlan = planRepository.findTopByMemberAndIsCompletedOrderByCreatedAtDesc(surroundingMember, true).orElseThrow(PlanNotFoundException::new);
 
-        // 회원의 상태가 STOP 이면 회원의 오늘 할 일을 가져온다.
-        if (surroundingMemberStatus.equals(Status.STOP)) {
-            Schedule surroundMemberTodaySchedule = scheduleRepository.findLatestSchedule(surroundingMember, LocalDate.now()).orElseThrow(ScheduleNotFoundException::new);
+        List<Path> pathsOfLatestPlan = pathRepository.findPathsByPlanAndIsCompleted(latestPlan, true);
 
-            surroundMemberTodos = todoRepository.findTodosWithCategoryBySchedule(surroundMemberTodaySchedule);
-        }
-        // 회원의 상태가 MOVE 나 FEEDBACK 이면 최근 계획의 할 일을 가져온다.
-        else {
-            Plan latestPlan = planRepository.findTopByMemberIdOrderByCreatedAtDesc(surroundingMemberId).orElseThrow(PlanNotFoundException::new);
-
-            List<Path> pathsOfLatestPlan = pathRepository.findByPlanAndType(latestPlan, TodoType.IN_PROGRESS);
-
-            surroundMemberTodos = pathsOfLatestPlan.stream()
-                    .flatMap(path -> path.getTodos().stream())
-                    .toList();
-        }
+        List<Todo> surroundMemberTodos = pathsOfLatestPlan.stream()
+                .flatMap(path -> path.getTodos().stream())
+                .toList();
 
         List<Long> surroundMemberParentTodoIds = todoRepository.findParentTodoIdsByParentTodoAndMemberAndType(surroundMemberTodos, selfMember, TodoType.SAVE);
          return SurroundingMemberInfo.of(surroundingMember.getNickname(),

--- a/backend/src/main/java/com/dubu/backend/todo/dto/response/MemberInfo.java
+++ b/backend/src/main/java/com/dubu/backend/todo/dto/response/MemberInfo.java
@@ -8,6 +8,7 @@ import java.util.Map;
 public record MemberInfo(@JsonUnwrapped MemberLocationInfo memberLocationInfo, List<String> category) {
     public static List<MemberInfo> from(List<MemberLocationInfo> memberLocationInfos, Map<Long, List<String>> memberToCategories) {
         return memberLocationInfos.stream()
+                .filter(info -> memberToCategories.get(info.memberId()) != null)
                 .map(info -> new MemberInfo(info, memberToCategories.get(info.memberId())))
                 .toList();
     }

--- a/backend/src/main/java/com/dubu/backend/todo/infra/repository/TodoRepository.java
+++ b/backend/src/main/java/com/dubu/backend/todo/infra/repository/TodoRepository.java
@@ -46,9 +46,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long>, CustomTodoRep
     @Query("SELECT t From Todo t WHERE t.member = :member AND t.parentTodo = :parentTodo AND t.type = :type")
     Optional<Todo> findByMemberAndParentTodoAndType(@Param("member") Member member, @Param("parentTodo") Todo parentTod, @Param("type") TodoType type);
 
-    @Query("SELECT t FROM Todo t JOIN FETCH t.category WHERE t.category.id in :categoryIds AND t.type = :type")
-    List<Todo> findTodosWithCategoryByCategoryIdsAndType(@Param("categoryIds")List<Long> categoryIds, @Param("type") TodoType type);
-
     // 경로로 조회
     @Query("SELECT t FROM Todo t WHERE t.path = :path")
     List<Todo> findTodosByPath(Path path);

--- a/backend/src/main/java/com/dubu/backend/todo/infra/repository/TodoRepository.java
+++ b/backend/src/main/java/com/dubu/backend/todo/infra/repository/TodoRepository.java
@@ -2,6 +2,7 @@ package com.dubu.backend.todo.infra.repository;
 
 import com.dubu.backend.member.domain.Member;
 import com.dubu.backend.plan.domain.Path;
+import com.dubu.backend.todo.dto.response.MemberCategoryInfo;
 import com.dubu.backend.todo.domain.Schedule;
 import com.dubu.backend.todo.domain.Todo;
 import com.dubu.backend.todo.domain.enums.TodoType;
@@ -45,6 +46,9 @@ public interface TodoRepository extends JpaRepository<Todo, Long>, CustomTodoRep
     @Query("SELECT t From Todo t WHERE t.member = :member AND t.parentTodo = :parentTodo AND t.type = :type")
     Optional<Todo> findByMemberAndParentTodoAndType(@Param("member") Member member, @Param("parentTodo") Todo parentTod, @Param("type") TodoType type);
 
+    @Query("SELECT t FROM Todo t JOIN FETCH t.category WHERE t.category.id in :categoryIds AND t.type = :type")
+    List<Todo> findTodosWithCategoryByCategoryIdsAndType(@Param("categoryIds")List<Long> categoryIds, @Param("type") TodoType type);
+
     // 경로로 조회
     @Query("SELECT t FROM Todo t WHERE t.path = :path")
     List<Todo> findTodosByPath(Path path);
@@ -60,5 +64,20 @@ public interface TodoRepository extends JpaRepository<Todo, Long>, CustomTodoRep
 
     @Query("SELECT t FROM Todo t WHERE t.path.id IN :pathIds AND t.type = :type AND t.isCompleted = true")
     List<Todo> findByPathIdsAndTypeAndIsCompleted(List<Long> pathIds, TodoType type);
+
+    @Query(value = """
+        WITH ranked_plan AS (
+            SELECT plan_id, row_number() over (partition by member_id order by created_at desc) as rn
+            FROM plan
+            WHERE member_id IN :memberIds AND is_completed <> 0
+        )
+            SELECT DISTINCT t.member_id, c.name
+            FROM todo t
+                     JOIN category c ON c.category_id = t.category_id
+                     JOIN path p ON p.path_id = t.path_id
+                     JOIN ranked_plan rp ON rp.plan_id = p.plan_id AND rp.rn = 1
+            WHERE t.is_completed = true;
+    """, nativeQuery = true)
+    List<MemberCategoryInfo> findTodoCountGroupByCategory(List<Long> memberIds);
 }
 

--- a/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepository.java
+++ b/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepository.java
@@ -15,6 +15,5 @@ import java.util.List;
 public interface CustomTodoRepository {
     Slice<Todo> findTodosUsingSingleCursor(Long cursor, TodoSearchCond cond, Pageable pageable);
     Slice<Todo> findTodosUsingCompositeCursor(Cursor cursor, TodoSearchCond cond, Pageable pageable);
-    List<MemberCategoryInfo> findTodoCountGroupByCategory(List<Member> members);
     List<Long> findTodosWithCategoryByCategoryIdsAndType(List<Long> categoryIds, TodoType type);
 }

--- a/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepository.java
+++ b/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepository.java
@@ -15,7 +15,6 @@ import java.util.List;
 public interface CustomTodoRepository {
     Slice<Todo> findTodosUsingSingleCursor(Long cursor, TodoSearchCond cond, Pageable pageable);
     Slice<Todo> findTodosUsingCompositeCursor(Cursor cursor, TodoSearchCond cond, Pageable pageable);
-    List<MemberCategoryInfo> findTodoCountGroupByCategoryForStopMembers(List<Member> members, LocalDate date);
-    List<MemberCategoryInfo> findTodoCountGroupByCategoryForMoveOrFeedbackMembers(List<Member> members);
+    List<MemberCategoryInfo> findTodoCountGroupByCategory(List<Member> members);
     List<Long> findTodosWithCategoryByCategoryIdsAndType(List<Long> categoryIds, TodoType type);
 }

--- a/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepositoryImpl.java
+++ b/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepositoryImpl.java
@@ -73,41 +73,6 @@ public class CustomTodoRepositoryImpl implements CustomTodoRepository{
         return new SliceImpl<>(results, pageable, hasNext);
     }
 
-    @Override
-    public List<MemberCategoryInfo> findTodoCountGroupByCategory(List<Member> members){
-        QPlan planSub = new QPlan("planSub");
-
-        return jpaQueryFactory.select(Projections.constructor(MemberCategoryInfo.class, todo.member.id, todo.category.name))
-                .distinct()
-                .from(todo)
-                .where(todo.path.in(
-                        JPAExpressions.select(path)
-                                .from(path)
-                                .where(path.plan.in(
-                                        JPAExpressions.select(plan)
-                                                .from(plan)
-                                                .where(Expressions.list(plan.member.id, plan.createdAt).in(
-                                                        JPAExpressions.select(planSub.member.id, planSub.createdAt.max())
-                                                                .from(planSub)
-                                                                .where(planSub.member.in(members), planSub.isCompleted)
-                                                                .groupBy(planSub.member)
-                                                ))
-                                ))
-                ))
-                .fetch();
-    }
-
-    @Override
-    public List<Long> findTodosWithCategoryByCategoryIdsAndType(List<Long> categoryIds, TodoType type) {
-        return jpaQueryFactory
-                .select(todo.id)
-                .from(todo)
-                .join(todo.category, category)
-                .where(category.id.in(categoryIds)
-                        .and(todo.type.eq(type)))
-                .fetch();
-    }
-
     private BooleanExpression cursor(Cursor cursor){
         Long categoryId = cursor.cursorCategoryId();
         String difficulty = cursor.cursorDifficulty();

--- a/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepositoryImpl.java
+++ b/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepositoryImpl.java
@@ -74,28 +74,7 @@ public class CustomTodoRepositoryImpl implements CustomTodoRepository{
     }
 
     @Override
-    public List<MemberCategoryInfo> findTodoCountGroupByCategoryForStopMembers(List<Member> members, LocalDate date){
-        QSchedule scheduleSub = new QSchedule("scheduleSub");
-
-        return jpaQueryFactory.select(Projections.constructor(MemberCategoryInfo.class, todo.member.id, todo.category.name))
-                .distinct()
-                .from(todo)
-                .where(todo.schedule.in(
-                        JPAExpressions.select(schedule)
-                                .from(schedule)
-                                .where(Expressions.list(schedule.member.id, schedule.date).in(
-                                        JPAExpressions.select(scheduleSub.member.id, scheduleSub.date.max())
-                                                .from(scheduleSub)
-                                                .where(scheduleSub.member.in(members)
-                                                        .and(scheduleSub.date.loe(date)))
-                                                .groupBy(scheduleSub.member)
-                                )))
-                )
-                .fetch();
-    }
-
-    @Override
-    public List<MemberCategoryInfo> findTodoCountGroupByCategoryForMoveOrFeedbackMembers(List<Member> members){
+    public List<MemberCategoryInfo> findTodoCountGroupByCategory(List<Member> members){
         QPlan planSub = new QPlan("planSub");
 
         return jpaQueryFactory.select(Projections.constructor(MemberCategoryInfo.class, todo.member.id, todo.category.name))
@@ -110,7 +89,7 @@ public class CustomTodoRepositoryImpl implements CustomTodoRepository{
                                                 .where(Expressions.list(plan.member.id, plan.createdAt).in(
                                                         JPAExpressions.select(planSub.member.id, planSub.createdAt.max())
                                                                 .from(planSub)
-                                                                .where(planSub.member.in(members))
+                                                                .where(planSub.member.in(members), planSub.isCompleted)
                                                                 .groupBy(planSub.member)
                                                 ))
                                 ))

--- a/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepositoryImpl.java
+++ b/backend/src/main/java/com/dubu/backend/todo/infra/repository/querydsl/CustomTodoRepositoryImpl.java
@@ -73,6 +73,18 @@ public class CustomTodoRepositoryImpl implements CustomTodoRepository{
         return new SliceImpl<>(results, pageable, hasNext);
     }
 
+    @Override
+    public List<Long> findTodosWithCategoryByCategoryIdsAndType(List<Long> categoryIds, TodoType type) {
+        return jpaQueryFactory
+                .select(todo.id)
+                .from(todo)
+                .join(todo.category, category)
+                .where(category.id.in(categoryIds)
+                        .and(todo.type.eq(type)))
+                .fetch();
+    }
+
+
     private BooleanExpression cursor(Cursor cursor){
         Long categoryId = cursor.cursorCategoryId();
         String difficulty = cursor.cursorDifficulty();


### PR DESCRIPTION
## Issue Number

close #199 
## As-Is
<!-- 문제 상황 정의 -->
지도(공유) 페이지에서 주변 사용자 할 일 조회 시 보여줄 데이터를 변경한다.

## To-Be
<!-- 변경 사항 -->
- [x] 사용자의 상태와 상관없이 종료한 최근 계획의 할 일을 사용한다.
- [x] 주변 사용자들의 카테 고리별 할 일 랭킹 조회 로직에서 쿼리 최적화를 진행한다.(CTE, index)

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced data retrieval, enabling more precise filtering of plans, tasks, and progress based on completion status.
  - Introduced grouping of tasks by category for improved overview and insights.

- **Refactor**
  - Streamlined the process for gathering surrounding member details and their associated tasks.
  - Improved filtering to ensure that only valid member information is processed.
  - Removed redundant data queries to simplify operations and boost efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->