### PR TITLE
[FIX] 통계 조회 시 활용 가능 시간 계산 로직 수정

### DIFF
--- a/backend/src/main/java/com/dubu/backend/todo/application/impl/statistic/StatisticServiceImpl.java
+++ b/backend/src/main/java/com/dubu/backend/todo/application/impl/statistic/StatisticServiceImpl.java
@@ -6,6 +6,7 @@ import com.dubu.backend.member.infra.repository.MemberRepository;
 import com.dubu.backend.plan.domain.Feedback;
 import com.dubu.backend.plan.domain.Path;
 import com.dubu.backend.plan.domain.Plan;
+import com.dubu.backend.plan.domain.enums.TrafficType;
 import com.dubu.backend.plan.infra.repository.PathRepository;
 import com.dubu.backend.plan.infra.repository.PlanRepository;
 import com.dubu.backend.todo.dto.response.DayStatisticInfo;
@@ -77,23 +78,26 @@ public class StatisticServiceImpl implements StatisticService {
 
 
     private DayStatisticInfo buildDailyStatisticInfo(LocalDate memberCreateDate, List<Category> categories, List<Plan> plans, List<Path> paths) {
-        int totalUsageTime = 0;
+        int totalAvailableTime = 0;
         int totalTodoCount = 0;
         List<Feedback> feedbacks = new ArrayList<>();
         CategoryTodoStatistics categoryTodoStatistics = new CategoryTodoStatistics(categories);
 
         for(Plan plan: plans){
-            totalUsageTime += plan.getTotalTime();
+            totalAvailableTime += plan.getTotalTime();
             feedbacks.add(plan.getFeedback());
         }
+
         for(Path path: paths){
-            for(Todo todo: path.getTodos()){
-                categoryTodoStatistics.countDoneTodo(todo);
-                totalTodoCount++;
+            if(path.getTrafficType() != TrafficType.WALK){
+                for(Todo todo: path.getTodos()){
+                    categoryTodoStatistics.countDoneTodo(todo);
+                    totalTodoCount++;
+                }
             }
         }
 
-        return DayStatisticInfo.of(memberCreateDate, totalUsageTime, totalTodoCount, feedbacks, categoryTodoStatistics.getCategoryTodoTimeCount());
+        return DayStatisticInfo.of(memberCreateDate, totalAvailableTime, totalTodoCount, feedbacks, categoryTodoStatistics.getCategoryTodoTimeCount());
     }
 
     private WeekStatisticInfo buildWeekStatisticInfo(LocalDate memberCreateDate, LocalDate startDate, List<Category> categories, List<Plan> thisWeekPlans, List<Plan> lastWeekPlans){
@@ -132,13 +136,8 @@ public class StatisticServiceImpl implements StatisticService {
         for(Plan plan: thisWeekPlans){
             LocalDate date = plan.getCreatedAt().toLocalDate();
             moodCountCollection.addMood(plan.getFeedback().getMood());
-            // 날짜별 통계
-            for (Path path : plan.getPaths()) {
-                if(path.getId() != null){
-                    dateAvailableTimeStatistics.addUsageTimeAtDate(date, path.getSectionTime());
-                    totalAvailableTime += path.getSectionTime();
-                }
-            }
+            totalAvailableTime += plan.getTotalTime();
+            dateAvailableTimeStatistics.addUsageTimeAtDate(date, plan.getTotalTime());
         }
 
         // 이번 주 카테고리별 통계 집계
@@ -156,8 +155,7 @@ public class StatisticServiceImpl implements StatisticService {
     // 활용 가능한 시간 계산
     private int calculateWeeklyUsageTime(List<Plan> plans){
         return plans.stream()
-                .flatMap(plan -> plan.getPaths().stream())
-                .mapToInt(Path::getSectionTime)
+                .mapToInt(Plan::getTotalTime)
                 .sum();
     }
 }


### PR DESCRIPTION
## Issue Number
close #228 

## As-Is
<!-- 문제 상황 정의 -->
계획의 경로에 도보(WALK)가 포함되어 활용 가능 시간 계산 로직을 변경한다.

## To-Be
<!-- 변경 사항 -->
- [ ] 활용가능 시간 계산을 Plan 의 total_titme 을 활용한다.

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved time statistics calculations for daily and weekly reports by focusing on available time metrics.
  - Refined filtering logic to exclude walking-related items from certain statistics.
  - Streamlined aggregation of plan times for a more straightforward and accurate overview of activity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->