### PR TITLE
[FIX] 주간 통계 조회 시 모든 Mood 타입에 대하여 데이터 제공 

### DIFF
--- a/backend/src/main/java/com/dubu/backend/todo/application/collection/statistic/MoodCountCollection.java
+++ b/backend/src/main/java/com/dubu/backend/todo/application/collection/statistic/MoodCountCollection.java
@@ -11,7 +11,11 @@ public class MoodCountCollection {
     private final Map<Mood, Integer> moodCount;
 
     public MoodCountCollection() {
-        this.moodCount = new HashMap<>();
+        moodCount = new HashMap<>();
+
+        for (Mood mood : Mood.values()) {
+            moodCount.put(mood, 0);
+        }
     }
 
     public void addMood(Mood mood){


### PR DESCRIPTION
## Issue Number
close #231 

## As-Is
<!-- 문제 상황 정의 -->
주간 통계 조회 시 피드백의 존재하지 않은 Mood 값도 0값으로 전송한다.

## To-Be
<!-- 변경 사항 -->
- [x] 일급 컬렉션 MoodCountCollection 초기화 시 모든 Mood 타입에 대하여 0으로 설정

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the initialization process for mood tracking to ensure every available mood option starts with a defined count, enhancing overall data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->