### PR TITLE
[FIX] 주간 통계 분 단위를 시간 단위로 변경

### DIFF
--- a/frontend/src/pages/RouteSelectPage/components/RouteResult/RouteList/RouteItem/RouteTimeInfo/index.tsx
+++ b/frontend/src/pages/RouteSelectPage/components/RouteResult/RouteList/RouteItem/RouteTimeInfo/index.tsx
@@ -2,16 +2,7 @@ import * as S from './RouteTimeInfo.styled';
 
 import Icon from '@/components/Icon';
 import theme from '@/styles/theme';
-
-const formatTime = (time: number) => {
-  if (time < 60) {
-    return `${time}분`;
-  }
-  const hour = Math.floor(time / 60);
-  const minute = time % 60;
-
-  return `${hour}시간 ${minute > 0 ? `${minute}분` : ''}`;
-};
+import { minutesToHours } from '@/utils/time';
 
 interface RouteTimeInfoProps {
   totalTime: number;
@@ -21,12 +12,12 @@ interface RouteTimeInfoProps {
 const RouteTimeInfo = ({ totalTime, totalSectionTime }: RouteTimeInfoProps) => {
   return (
     <S.TimeContainer>
-      <S.TotalTime>{formatTime(totalTime)}</S.TotalTime>
+      <S.TotalTime>{minutesToHours(totalTime)}</S.TotalTime>
 
       <S.TotalSectionTimeBox>
         <Icon icon="Fire" width={16} height={16} color={theme.colors.green600} />
         <span>활용 가능 시간</span>
-        <S.TotalSectionTime>{formatTime(totalSectionTime)}</S.TotalSectionTime>
+        <S.TotalSectionTime>{minutesToHours(totalSectionTime)}</S.TotalSectionTime>
       </S.TotalSectionTimeBox>
     </S.TimeContainer>
   );

--- a/frontend/src/pages/WeekStatisticsPage/components/WeekStatisticsMain/WeekOverview/index.tsx
+++ b/frontend/src/pages/WeekStatisticsPage/components/WeekStatisticsMain/WeekOverview/index.tsx
@@ -3,6 +3,7 @@ import * as S from './WeekOverview.styled';
 import MOOD_DISSATISFIED from '@/assets/images/moodDissatisfied.webp';
 import MOOD_MODERATE from '@/assets/images/moodModerate.webp';
 import MOOD_SATISFIED from '@/assets/images/moodSatisfied.webp';
+import { minutesToHours } from '@/utils/time';
 
 const MOOD_IMAGES: Record<string, string> = {
   DISSATISFIED: MOOD_DISSATISFIED,
@@ -38,7 +39,7 @@ const WeekOverview = ({
 
       <S.WeekOverviewContent>
         <S.WeekAchievement>
-          <span>{totalAvailableTime}분 동안</span>
+          <span>{minutesToHours(totalAvailableTime)} 동안</span>
           <span>{totalTodoCount}개의 할 일을 했어요</span>
         </S.WeekAchievement>
 
@@ -46,7 +47,7 @@ const WeekOverview = ({
           <S.CompareTitle>지난 주와의 비교</S.CompareTitle>
           <S.CompareValue>
             {lastWeekDiff > 0 && '+'}
-            {lastWeekDiff}분
+            {minutesToHours(lastWeekDiff)}
           </S.CompareValue>
         </S.CompareLastWeek>
 

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -6,3 +6,13 @@ export const formatDateHeader = (targetDate: Date) => {
 
   return `${month}월 ${date}일 ${day}`;
 };
+
+export const minutesToHours = (time: number) => {
+  const sign = time < 0 ? '-' : '';
+  const absTime = Math.abs(time);
+
+  const hour = Math.floor(absTime / 60);
+  const minute = absTime % 60;
+
+  return `${sign}${hour > 0 ? `${hour}시간` : ''} ${minute > 0 ? `${minute}분` : ''}`;
+};


### PR DESCRIPTION
## Issue Number
close #239 
## As-Is
<!-- 문제 상황 정의 -->
- 주간 통계의 활용 시간이 분 단위로 표시되어 가독성이 좋지 않았음
## To-Be
<!-- 변경 사항 -->
- [x] 분 단위 시간을 시간 단위로 변환하는 유틸함수 추가

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Time durations on the Route Details and Weekly Statistics pages are now displayed in a clear hour-and-minute format for enhanced readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->