### PR TITLE
[FEAT] FCM 기반 푸시 알림 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,7 @@ jobs:
               -e VAPID_PRIVATE_KEY=${{ secrets.VAPID_PRIVATE_KEY }} \
               -e ADMIN_EMAIL=${{ secrets.ADMIN_EMAIL }} \
               -e NOTIFICATION_URL=${{ secrets.NOTIFICATION_URL }} \
+              -e FIREBASE_SERVICE_ACCOUNT_JSON=${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }} \
               -e PROD_SERVER_URL=${{ secrets.PROD_SERVER_URL }} \
               --name ${{ secrets.DOCKER_REPOSITORY }} \
               ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	// web -push
 	implementation 'nl.martijndwars:web-push:5.1.0'
 
+	// FCM
+	implementation 'com.google.firebase:firebase-admin:9.4.3'
+
 	// MQ
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 

--- a/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/dubu/backend/global/exception/ErrorCode.java
@@ -75,6 +75,10 @@ public enum ErrorCode {
     // Schedule
     SCHEDULE_NOT_FOUND(NOT_FOUND, "스케줄을 찾을 수 없습니다."),
 
+    // FCM
+    DUPLICATE_FCM_TOKEN(BAD_REQUEST, "이미 저장된 FCM Token 입니다. memberId : %d"),
+    NOT_FOUND_FCM_TOKEN(NOT_FOUND, "해당 멤버의 FCM TOKEN이 존재하지 않습니다. memberId : %d"),
+
     // External
     NAVER_SERVICE_UNAVAILABLE(SERVICE_UNAVAILABLE, "네이버 API 서버가 장애 상태입니다."),
     KAKAO_SERVICE_UNAVAILABLE(SERVICE_UNAVAILABLE, "카카오 API 서버가 장애 상태입니다."),

--- a/backend/src/main/java/com/dubu/backend/notification/api/NotificationApi.java
+++ b/backend/src/main/java/com/dubu/backend/notification/api/NotificationApi.java
@@ -1,5 +1,6 @@
 package com.dubu.backend.notification.api;
 
+import com.dubu.backend.notification.dto.FcmTokenDto;
 import com.dubu.backend.notification.dto.PushMessageDto;
 import com.dubu.backend.notification.dto.PushSubscriptionDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -89,6 +90,62 @@ public interface NotificationApi {
                     )
             )
             PushSubscriptionDto subscription
+    );
+
+    @Operation(
+            summary = "FCM 토큰 등록",
+            description = """
+                    FCM을 이용해 알림을 받기 위해서는 디바이스/브라우저에서 발급된 
+                    토큰(deviceToken)을 서버에 등록해야 합니다. 
+                    <p>이 API 호출 시 서버가 memberId와 FCM 토큰을 매핑하여 저장합니다.</p>
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "FCM 토큰 등록 성공 (응답 본문 없음)"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "회원이 존재하지 않는 경우 (MEMBER_NOT_FOUND)",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = ErrorResponseExample.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "회원 미존재 에러 예시",
+                                            value = """
+                                                    {
+                                                      "errorCode": "MEMBER_NOT_FOUND",
+                                                      "message": "회원을 찾을 수 없습니다. memberId : 9999"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+    })
+    void registerFcmToken(
+            Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "FCM 토큰 등록 요청 DTO",
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FcmTokenDto.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "FCM 토큰 등록 예시",
+                                            value = """
+                                                    {
+                                                      "deviceToken": "fcmTokenExample12345"
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            )
+            FcmTokenDto fcmTokenDto
     );
 
     @Operation(

--- a/backend/src/main/java/com/dubu/backend/notification/api/NotificationController.java
+++ b/backend/src/main/java/com/dubu/backend/notification/api/NotificationController.java
@@ -32,7 +32,7 @@ public class NotificationController {
             @RequestAttribute("memberId") Long memberId,
             @RequestBody FcmTokenDto fcmTokenDto
             ) {
-        fcmService.saveOrUpdateToken(memberId, fcmTokenDto);
+        fcmService.saveToken(memberId, fcmTokenDto);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/backend/src/main/java/com/dubu/backend/notification/api/NotificationController.java
+++ b/backend/src/main/java/com/dubu/backend/notification/api/NotificationController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/notification")
-public class NotificationController {
+public class NotificationController implements NotificationApi {
 
     private final NotificationService notificationService;
     private final FcmService fcmService;
@@ -31,7 +31,7 @@ public class NotificationController {
     public void registerFcmToken(
             @RequestAttribute("memberId") Long memberId,
             @RequestBody FcmTokenDto fcmTokenDto
-            ) {
+    ) {
         fcmService.saveToken(memberId, fcmTokenDto);
     }
 

--- a/backend/src/main/java/com/dubu/backend/notification/api/NotificationController.java
+++ b/backend/src/main/java/com/dubu/backend/notification/api/NotificationController.java
@@ -1,6 +1,8 @@
 package com.dubu.backend.notification.api;
 
+import com.dubu.backend.notification.application.FcmService;
 import com.dubu.backend.notification.application.NotificationService;
+import com.dubu.backend.notification.dto.FcmTokenDto;
 import com.dubu.backend.notification.dto.PushMessageDto;
 import com.dubu.backend.notification.dto.PushSubscriptionDto;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class NotificationController {
 
     private final NotificationService notificationService;
+    private final FcmService fcmService;
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/subscribe")
@@ -21,6 +24,15 @@ public class NotificationController {
             @RequestBody PushSubscriptionDto subscription
     ) {
         notificationService.saveSubscription(memberId, subscription);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/fcm/token")
+    public void registerFcmToken(
+            @RequestAttribute("memberId") Long memberId,
+            @RequestBody FcmTokenDto fcmTokenDto
+            ) {
+        fcmService.saveOrUpdateToken(memberId, fcmTokenDto);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/backend/src/main/java/com/dubu/backend/notification/application/FcmService.java
+++ b/backend/src/main/java/com/dubu/backend/notification/application/FcmService.java
@@ -59,7 +59,6 @@ public class FcmService {
                         .build())
                 .setToken(currentFcmToken.getDeviceToken())
                 .build());
-
-        System.out.println("Sent message: " + response);
+        log.info("[FCM 전송 결과] response: {}", response);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/notification/application/FcmService.java
+++ b/backend/src/main/java/com/dubu/backend/notification/application/FcmService.java
@@ -1,0 +1,65 @@
+package com.dubu.backend.notification.application;
+
+import com.dubu.backend.member.domain.Member;
+import com.dubu.backend.member.exception.MemberNotFoundException;
+import com.dubu.backend.member.infra.repository.MemberRepository;
+import com.dubu.backend.notification.domain.FcmToken;
+import com.dubu.backend.notification.dto.FcmTokenDto;
+import com.dubu.backend.notification.dto.PushMessageDto;
+import com.dubu.backend.notification.exception.DuplicateFcmTokenException;
+import com.dubu.backend.notification.exception.NotFoundFcmTokenException;
+import com.dubu.backend.notification.infra.repository.FcmTokenRepository;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+    private final MemberRepository memberRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+    @Transactional
+    public void saveOrUpdateToken(Long memberId, FcmTokenDto fcmTokenDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        fcmTokenRepository.findByMemberId(memberId)
+                .ifPresentOrElse(
+                        existingToken -> {
+                            if(Objects.equals(existingToken.getDeviceToken(), fcmTokenDto.deviceToken())){
+                                throw new DuplicateFcmTokenException(memberId);
+                            }
+                            fcmTokenRepository.save(FcmToken.createFcmToken(member, fcmTokenDto.deviceToken()));
+                            log.info("[FCM Token 신규 저장] memberId={}", memberId);
+                        },
+                        () -> {
+                            fcmTokenRepository.save(FcmToken.createFcmToken(member, fcmTokenDto.deviceToken()));
+                            log.info("[FCM Token 신규 저장] memberId={}", memberId);
+                        }
+                );
+    }
+
+    public void sendMessage(PushMessageDto message) throws FirebaseMessagingException {
+        FcmToken currentFcmToken =  fcmTokenRepository.findByMemberId(message.memberId())
+                .orElseThrow(() -> new NotFoundFcmTokenException(message.memberId()));
+
+        String response = FirebaseMessaging.getInstance().send(Message.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(message.title())
+                        .setBody(message.body())
+                        .build())
+                .setToken(currentFcmToken.getDeviceToken())
+                .build());
+
+        System.out.println("Sent message: " + response);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/notification/application/FcmService.java
+++ b/backend/src/main/java/com/dubu/backend/notification/application/FcmService.java
@@ -28,7 +28,7 @@ public class FcmService {
     private final FcmTokenRepository fcmTokenRepository;
 
     @Transactional
-    public void saveOrUpdateToken(Long memberId, FcmTokenDto fcmTokenDto) {
+    public void saveToken(Long memberId, FcmTokenDto fcmTokenDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 

--- a/backend/src/main/java/com/dubu/backend/notification/application/NotificationService.java
+++ b/backend/src/main/java/com/dubu/backend/notification/application/NotificationService.java
@@ -1,6 +1,5 @@
 package com.dubu.backend.notification.application;
 
-
 import com.dubu.backend.member.domain.Member;
 import com.dubu.backend.member.dto.MemberStatusChangeDto;
 import com.dubu.backend.member.exception.MemberNotFoundException;

--- a/backend/src/main/java/com/dubu/backend/notification/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/dubu/backend/notification/config/FirebaseConfig.java
@@ -6,9 +6,10 @@ import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 @Configuration
 public class FirebaseConfig {
@@ -19,7 +20,8 @@ public class FirebaseConfig {
     @PostConstruct
     public void init(){
         try{
-            InputStream serviceAccount = new ClassPathResource("worryboxFirebaseKey.json").getInputStream();
+            InputStream serviceAccount = new ByteArrayInputStream(firebaseConfigJson.getBytes(StandardCharsets.UTF_8));
+
             FirebaseOptions options = new FirebaseOptions.Builder()
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();

--- a/backend/src/main/java/com/dubu/backend/notification/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/dubu/backend/notification/config/FirebaseConfig.java
@@ -1,0 +1,34 @@
+package com.dubu.backend.notification.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.InputStream;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.service-account-json}")
+    private String firebaseConfigJson;
+
+    @PostConstruct
+    public void init(){
+        try{
+            InputStream serviceAccount = new ClassPathResource("worryboxFirebaseKey.json").getInputStream();
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) { // FirebaseApp이 이미 초기화되어 있지 않은 경우에만 초기화 실행
+                FirebaseApp.initializeApp(options);
+            }
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/notification/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/dubu/backend/notification/config/FirebaseConfig.java
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 
 @Configuration
 public class FirebaseConfig {
-
     @Value("${firebase.service-account-json}")
     private String firebaseConfigJson;
 
@@ -26,7 +25,7 @@ public class FirebaseConfig {
                     .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                     .build();
 
-            if (FirebaseApp.getApps().isEmpty()) { // FirebaseApp이 이미 초기화되어 있지 않은 경우에만 초기화 실행
+            if (FirebaseApp.getApps().isEmpty()) {
                 FirebaseApp.initializeApp(options);
             }
         } catch (Exception e){

--- a/backend/src/main/java/com/dubu/backend/notification/domain/FcmToken.java
+++ b/backend/src/main/java/com/dubu/backend/notification/domain/FcmToken.java
@@ -1,0 +1,37 @@
+package com.dubu.backend.notification.domain;
+
+import com.dubu.backend.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "deviceToken"})
+})
+public class FcmToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false)
+    private String deviceToken;
+
+    public static FcmToken createFcmToken(Member member, String deviceToken) {
+        return FcmToken.builder()
+                .member(member)
+                .deviceToken(deviceToken)
+                .build();
+    }
+
+    public void updateFcmToken(String deviceToken) {
+        this.deviceToken = deviceToken;
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/notification/domain/FcmToken.java
+++ b/backend/src/main/java/com/dubu/backend/notification/domain/FcmToken.java
@@ -30,8 +30,4 @@ public class FcmToken {
                 .deviceToken(deviceToken)
                 .build();
     }
-
-    public void updateFcmToken(String deviceToken) {
-        this.deviceToken = deviceToken;
-    }
 }

--- a/backend/src/main/java/com/dubu/backend/notification/dto/FcmTokenDto.java
+++ b/backend/src/main/java/com/dubu/backend/notification/dto/FcmTokenDto.java
@@ -1,0 +1,4 @@
+package com.dubu.backend.notification.dto;
+
+public record FcmTokenDto(String deviceToken) {
+}

--- a/backend/src/main/java/com/dubu/backend/notification/exception/DuplicateFcmTokenException.java
+++ b/backend/src/main/java/com/dubu/backend/notification/exception/DuplicateFcmTokenException.java
@@ -1,0 +1,16 @@
+package com.dubu.backend.notification.exception;
+
+import com.dubu.backend.global.exception.BadRequestException;
+
+import static com.dubu.backend.global.exception.ErrorCode.DUPLICATE_FCM_TOKEN;
+
+public class DuplicateFcmTokenException extends BadRequestException {
+    public DuplicateFcmTokenException(Long memberId) {
+        super(DUPLICATE_FCM_TOKEN.getMessage().formatted(memberId));
+    }
+
+    @Override
+    public String getErrorCode() {
+      return DUPLICATE_FCM_TOKEN.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/notification/exception/NotFoundFcmTokenException.java
+++ b/backend/src/main/java/com/dubu/backend/notification/exception/NotFoundFcmTokenException.java
@@ -1,0 +1,16 @@
+package com.dubu.backend.notification.exception;
+
+import com.dubu.backend.global.exception.NotFoundException;
+
+import static com.dubu.backend.global.exception.ErrorCode.NOT_FOUND_FCM_TOKEN;
+
+public class NotFoundFcmTokenException extends NotFoundException {
+    public NotFoundFcmTokenException(Long memberId) {
+        super(NOT_FOUND_FCM_TOKEN.getMessage().formatted(memberId));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return NOT_FOUND_FCM_TOKEN.name();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/notification/infra/amqp/PushMessageEventConsumer.java
+++ b/backend/src/main/java/com/dubu/backend/notification/infra/amqp/PushMessageEventConsumer.java
@@ -1,5 +1,6 @@
 package com.dubu.backend.notification.infra.amqp;
 
+import com.dubu.backend.notification.application.FcmService;
 import com.dubu.backend.notification.application.NotificationService;
 import com.dubu.backend.notification.config.NotificationRabbitMQConfig;
 import com.dubu.backend.notification.dto.PushMessageDto;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PushMessageEventConsumer {
     private final NotificationService notificationService;
+    private final FcmService fcmService;
     private final ObjectMapper objectMapper;
 
     @RabbitListener(queues = NotificationRabbitMQConfig.DLX_QUEUE_NAME)
@@ -22,6 +24,7 @@ public class PushMessageEventConsumer {
             PushMessageDto message = objectMapper.readValue(jsonMessage, PushMessageDto.class);
             log.info("[푸시 알림 이벤트 소모] message : {}", message);
             notificationService.sendPushNotification(message);
+            fcmService.sendMessage(message);
         } catch (Exception e) {
             log.error("메시지 변환 중 오류 발생: {}", e.getMessage(), e);
         }

--- a/backend/src/main/java/com/dubu/backend/notification/infra/repository/FcmTokenRepository.java
+++ b/backend/src/main/java/com/dubu/backend/notification/infra/repository/FcmTokenRepository.java
@@ -1,0 +1,10 @@
+package com.dubu.backend.notification.infra.repository;
+
+import com.dubu.backend.notification.domain.FcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+    Optional<FcmToken> findByMemberId(Long memberId);
+}

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -87,6 +87,9 @@ admin:
 notification:
   url: ${NOTIFICATION_URL}
 
+firebase:
+  service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Issue Number
#245 
## As-Is
<!-- 문제 상황 정의 -->
FCM 기반 푸시 알림 구현합니다.

## To-Be
<!-- 변경 사항 -->
- [x] FCM 토큰 저장 API
- [x] FCM 푸시 알림 로직 구현

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a push notification endpoint allowing device token registration.
  - Enhanced error messaging for duplicate or missing tokens.
  - Improved push notification delivery with enhanced Firebase Cloud Messaging integration.

- **Chores**
  - Updated deployment configurations for secure Firebase service credential management.
  - Refined project dependencies and settings to support the new notification features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->