### PR TITLE
[FIX] 이동중 오늘 할일 조회 에러 해결 & 추천 할 일을 추가할 때마다 새로고침되는 문제 해결 &  드래그 앤 드롭에 의한 클릭 이벤트 방지

### DIFF
--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -18,6 +18,7 @@ export const TODO_TOAST_MESSAGE = {
   addFavorite: '즐겨찾기에 추가되었어요',
   deleteFavorite: '즐겨찾기에서 삭제되었어요',
   location: '현재 위치를 성공적으로 불러왔습니다!',
+  move: '페이지가 이동되었어요.',
 };
 
 type clientErrorType = 'LOCATION' | 'LOCATION_PERMISSION' | 'UPDATE_PATH_TODO' | 'CHECK';
@@ -29,7 +30,7 @@ export const ERROR_MESSAGE: Record<ErrorCode | clientErrorType, string> = {
   TOKEN_EXPIRED: '로그인 세션이 만료되었어요. 다시 로그인해 주세요.',
 
   INVALID_MEMBER_STATUS: '현재 상태에서는 이 작업을 수행할 수 없어요.',
-  TODO_LIMIT_EXCEEDED: '할 일 개수를 초과했어요. 더 이상 추가할 수 없어요.',
+  TODO_LIMIT_EXCEEDED: '계획한 할 일의 개수가 너무 많아요!',
   METHOD_ARGUMENT_TYPE_MISMATCH: '잘못된 요청입니다. 입력 값을 확인해 주세요.',
   PATH_ID_NOT_PROVIDED: '경로 정보가 누락되었어요. 다시 시도해 주세요.',
 

--- a/frontend/src/pages/EditPage/components/FavoriteTab/index.tsx
+++ b/frontend/src/pages/EditPage/components/FavoriteTab/index.tsx
@@ -9,11 +9,9 @@ import TodoEditItem from '../TodoEditItem';
 
 import IconButton from '@/components/Button/IconButton';
 import Icon from '@/components/Icon';
-import { MAX_TODO_ITEM_LENGTH, TODO_TYPE } from '@/constants/config';
+import { TODO_TYPE } from '@/constants/config';
 import { TODO_TOAST_MESSAGE } from '@/constants/message';
-import useQueryParamsDate from '@/hooks/useQueryParamsDate';
 import useToast from '@/hooks/useToast';
-import useTodoListQuery from '@/hooks/useTodoListQuery';
 import { TodoType } from '@/types/todo';
 
 interface FavoriteTabProps {
@@ -22,9 +20,6 @@ interface FavoriteTabProps {
 }
 
 const FavoriteTab = ({ todoType, planId }: FavoriteTabProps) => {
-  const { dateType } = useQueryParamsDate();
-
-  const { data: todoList } = useTodoListQuery(dateType, Number(planId));
   const {
     data: favoriteTodoList,
     hasNextPage,
@@ -42,14 +37,6 @@ const FavoriteTab = ({ todoType, planId }: FavoriteTabProps) => {
   const isFavoritePage = todoType === TODO_TYPE.SAVE;
 
   const handleAddTodoFromFavorite = (todoId: number) => {
-    const isLimitType = todoType === TODO_TYPE.TODAY || todoType === TODO_TYPE.TOMORROW;
-
-    if (isLimitType && todoList && todoList.length >= MAX_TODO_ITEM_LENGTH) {
-      toast({ message: TODO_TOAST_MESSAGE.limit(dateType) });
-
-      return;
-    }
-
     addTodoFromArchived(
       { todoType, todoId, planId: Number(planId) },
       {

--- a/frontend/src/pages/EditPage/components/RecommendTab/index.tsx
+++ b/frontend/src/pages/EditPage/components/RecommendTab/index.tsx
@@ -4,11 +4,8 @@ import TodoEditItem from '../TodoEditItem';
 
 import IconButton from '@/components/Button/IconButton';
 import Icon from '@/components/Icon';
-import { MAX_TODO_ITEM_LENGTH } from '@/constants/config';
 import { TODO_TOAST_MESSAGE } from '@/constants/message';
-import useQueryParamsDate from '@/hooks/useQueryParamsDate';
 import useToast from '@/hooks/useToast';
-import useTodoListQuery from '@/hooks/useTodoListQuery';
 import useRecommendTodoListQuery from '@/pages/EditPage/hooks/useRecommendListQuery';
 import { TodoType } from '@/types/todo';
 
@@ -18,9 +15,6 @@ interface RecommendTabProps {
 }
 
 const RecommendTab = ({ todoType, planId }: RecommendTabProps) => {
-  const { dateType } = useQueryParamsDate();
-
-  const { data: todoList } = useTodoListQuery(dateType, Number(planId));
   const { data: recommendTodoList } = useRecommendTodoListQuery(todoType, Number(planId));
   const { mutate: addTodoFromArchived } = useAddTodoFromArchivedMutation();
   const { toast } = useToast();
@@ -29,12 +23,6 @@ const RecommendTab = ({ todoType, planId }: RecommendTabProps) => {
   const finalURL = `${routeURL}?dateType=${todoType}`;
 
   const handleAddTodoFromRecommend = (todoId: number) => {
-    if (todoList && todoList.length >= MAX_TODO_ITEM_LENGTH) {
-      toast({ message: TODO_TOAST_MESSAGE.limit(dateType) });
-
-      return;
-    }
-
     addTodoFromArchived(
       { todoType, todoId, planId: Number(planId) },
       { onSuccess: () => toast({ message: TODO_TOAST_MESSAGE.add(todoType) }) },

--- a/frontend/src/pages/EditPage/hooks/useAddTodoFromArchivedMutation.ts
+++ b/frontend/src/pages/EditPage/hooks/useAddTodoFromArchivedMutation.ts
@@ -87,7 +87,6 @@ const useAddTodoFromArchivedMutation = (
 
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.todoList] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.routeTodoList] });
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendLimit] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendAll] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.favorite] });
     },

--- a/frontend/src/pages/EditPage/hooks/useAddTodoMutation.ts
+++ b/frontend/src/pages/EditPage/hooks/useAddTodoMutation.ts
@@ -23,7 +23,6 @@ const useAddTodoMutation = () => {
       } else {
         queryClient.invalidateQueries({ queryKey: [QUERY_KEY.todoList] });
         queryClient.invalidateQueries({ queryKey: [QUERY_KEY.routeTodoList] });
-        queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendLimit] });
         queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendAll] });
         queryClient.invalidateQueries({ queryKey: [QUERY_KEY.favorite] });
       }

--- a/frontend/src/pages/EditPage/hooks/useDeleteTodoMutation.ts
+++ b/frontend/src/pages/EditPage/hooks/useDeleteTodoMutation.ts
@@ -13,7 +13,6 @@ const useDeleteTodoMutation = (todoType: TodoType) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.todoList] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.routeTodoList] });
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendLimit] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendAll] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.favorite] });
     },

--- a/frontend/src/pages/EditPage/hooks/useEditTodoMutation.ts
+++ b/frontend/src/pages/EditPage/hooks/useEditTodoMutation.ts
@@ -14,7 +14,6 @@ const useEditTodoMutation = (todoType: TodoType) => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.routeTodoList, todoType] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.todoList, todoType] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.favorite, todoType] });
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendLimit, todoType] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendAll, todoType] });
     },
   });

--- a/frontend/src/pages/EditPage/hooks/useRecommendListQuery.ts
+++ b/frontend/src/pages/EditPage/hooks/useRecommendListQuery.ts
@@ -8,7 +8,7 @@ const useRecommendTodoListQuery = (todoType: TodoType, planId?: number) => {
   return useQuery({
     queryKey: [QUERY_KEY.recommendLimit, todoType, planId || 0],
     queryFn: () => getRecommendLimitTodoList(todoType, planId),
-    staleTime: Infinity,
+    gcTime: 0,
   });
 };
 

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
@@ -27,13 +27,11 @@ const PlanContent = ({ paths }: PlanContentProps) => {
   const [draggingTodo, setDraggingTodo] = useState<DraggingTodo | null>(null);
   const timeBlockRefs = useRef(new Map<number, HTMLElement>());
   const longPressTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const isDraggingRef = useRef(false);
 
   const { mutateAsync: updatePathTodo } = useUpdatePathTodoMutation();
   const { toast } = useToast();
 
   const handleTouchStart = (e: TouchEvent<HTMLElement>, todo: PathTodo) => {
-    isDraggingRef.current = false;
     const touch = e.touches[0];
     const targetElement = e.currentTarget;
 
@@ -42,7 +40,6 @@ const PlanContent = ({ paths }: PlanContentProps) => {
     const offsetY = touch.pageY - targetElement.offsetTop;
 
     longPressTimeoutRef.current = setTimeout(() => {
-      isDraggingRef.current = true;
       setDraggingTodo({
         todo,
         x: touch.pageX - offsetX,
@@ -54,10 +51,9 @@ const PlanContent = ({ paths }: PlanContentProps) => {
   };
 
   const handleTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
-    if (!isDraggingRef.current) {
-      clearTimeout(longPressTimeoutRef.current!); // 스크롤 시 터치 취소
-
-      return;
+    if (longPressTimeoutRef.current) {
+      clearTimeout(longPressTimeoutRef.current); // 스크롤 시 터치 취소
+      longPressTimeoutRef.current = null;
     }
 
     if (!draggingTodo) return;
@@ -78,6 +74,7 @@ const PlanContent = ({ paths }: PlanContentProps) => {
   const handleTouchEnd = async (e: React.TouchEvent<HTMLElement>) => {
     if (longPressTimeoutRef.current) {
       clearTimeout(longPressTimeoutRef.current);
+      longPressTimeoutRef.current = null;
     }
 
     if (!draggingTodo) return;

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
@@ -109,8 +109,8 @@ const PlanContent = ({ paths }: PlanContentProps) => {
 
   useEffect(() => {
     const handleGlobalTouchEnd = (e: globalThis.TouchEvent) => {
-      alert('외부면 그냥 드래그앤드롭으로 인한 클릭 다막아');
-      // if (!draggingTodo) return;
+      alert('외부면 draggingTodo 없으면 클릭 막아');
+      if (!draggingTodo) return;
 
       e.preventDefault();
       // handleTouchEnd(e as unknown as React.TouchEvent<HTMLElement>);
@@ -119,7 +119,7 @@ const PlanContent = ({ paths }: PlanContentProps) => {
     document.addEventListener('touchend', handleGlobalTouchEnd);
 
     return () => document.removeEventListener('touchend', handleGlobalTouchEnd);
-  }, []);
+  }, [draggingTodo]);
 
   return (
     <S.PlanContent>

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
@@ -1,4 +1,4 @@
-import { TouchEvent, useRef, useState } from 'react';
+import { TouchEvent, useEffect, useRef, useState } from 'react';
 
 import TimeBlockContent from '..';
 import * as S from './PlanContent.styled';
@@ -79,6 +79,7 @@ const PlanContent = ({ paths }: PlanContentProps) => {
 
     if (!draggingTodo) return;
 
+    alert('내부도 실행');
     e.preventDefault();
 
     const touch = e.changedTouches[0];
@@ -103,6 +104,17 @@ const PlanContent = ({ paths }: PlanContentProps) => {
 
     setDraggingTodo(null);
   };
+
+  useEffect(() => {
+    const handleGlobalTouchEnd = (e: globalThis.TouchEvent) => {
+      alert('외부여도 클릭 이벤트 막아!');
+      handleTouchEnd(e as unknown as React.TouchEvent<HTMLElement>);
+    };
+
+    document.addEventListener('touchend', handleGlobalTouchEnd);
+
+    return () => document.removeEventListener('touchend', handleGlobalTouchEnd);
+  }, []);
 
   return (
     <S.PlanContent>

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
@@ -81,7 +81,6 @@ const PlanContent = ({ paths }: PlanContentProps) => {
 
     if (!draggingTodo) return;
 
-    alert('내부도 실행');
     e.preventDefault();
 
     const touch = e.changedTouches[0];
@@ -109,11 +108,9 @@ const PlanContent = ({ paths }: PlanContentProps) => {
 
   useEffect(() => {
     const handleGlobalTouchEnd = (e: globalThis.TouchEvent) => {
-      alert('외부면 draggingTodo 없으면 클릭 막아');
       if (!draggingTodo) return;
 
       e.preventDefault();
-      // handleTouchEnd(e as unknown as React.TouchEvent<HTMLElement>);
     };
 
     document.addEventListener('touchend', handleGlobalTouchEnd);

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
@@ -109,8 +109,11 @@ const PlanContent = ({ paths }: PlanContentProps) => {
 
   useEffect(() => {
     const handleGlobalTouchEnd = (e: globalThis.TouchEvent) => {
-      alert('외부여도 클릭 이벤트 막아!');
-      handleTouchEnd(e as unknown as React.TouchEvent<HTMLElement>);
+      alert('외부면 그냥 드래그앤드롭으로 인한 클릭 다막아');
+      // if (!draggingTodo) return;
+
+      e.preventDefault();
+      // handleTouchEnd(e as unknown as React.TouchEvent<HTMLElement>);
     };
 
     document.addEventListener('touchend', handleGlobalTouchEnd);

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/PlanContent/index.tsx
@@ -72,6 +72,8 @@ const PlanContent = ({ paths }: PlanContentProps) => {
   };
 
   const handleTouchEnd = async (e: React.TouchEvent<HTMLElement>) => {
+    e.stopPropagation();
+
     if (longPressTimeoutRef.current) {
       clearTimeout(longPressTimeoutRef.current);
       longPressTimeoutRef.current = null;

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
@@ -14,6 +14,7 @@ interface TimeBlockItemProps {
   onTouchStart: (e: TouchEvent<HTMLDivElement>, todo: PathTodo) => void;
   onTouchMove: (e: TouchEvent<HTMLDivElement>) => void;
   draggingTodo: DraggingTodo | null;
+  isDraggingTodo: boolean;
   itemRef?: LegacyRef<HTMLDivElement>;
 }
 
@@ -22,16 +23,20 @@ const TimeBlockItem = ({
   onTouchStart,
   onTouchMove,
   draggingTodo,
+  isDraggingTodo,
   itemRef,
 }: TimeBlockItemProps) => {
   const { todoId, category, title, memo, isDone } = todo;
   const isDragging = draggingTodo?.todo.todoId === todoId;
 
-  const { handleCheckTodo, handleUncheckTodo, isAnimatingCheck } = useCheckTodo(todo, isDragging);
+  const { handleCheckTodo, handleUncheckTodo, isAnimatingCheck } = useCheckTodo(
+    todo,
+    isDraggingTodo,
+  );
   const showTodoBottomSheet = useShowTodoBottomSheet();
 
   const handleViewTodo = () => {
-    if (isDragging) return;
+    if (isDraggingTodo) return;
 
     showTodoBottomSheet(todo);
   };

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
@@ -37,7 +37,7 @@ const TimeBlockItem = ({
 
   const handleViewTodo = () => {
     if (isDraggingTodo) return;
-
+    alert(`dragging: ${draggingTodo?.todo.title}`);
     showTodoBottomSheet(todo);
   };
 
@@ -59,6 +59,9 @@ const TimeBlockItem = ({
         <Icon icon={ICON_MAPPER[category]} cursor="pointer" width={28} height={28} />
       </S.CheckIconWrapper>
       <S.TimeBlockContent onClick={handleViewTodo}>
+        <span>
+          {isDraggingTodo.toString()} {isDragging.toString()}
+        </span>
         <S.TodoTitle $isDone={isDone}>{title}</S.TodoTitle>
         <S.TodoMemo>{memo}</S.TodoMemo>
       </S.TimeBlockContent>

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/TimeBlockItem/index.tsx
@@ -14,7 +14,7 @@ interface TimeBlockItemProps {
   onTouchStart: (e: TouchEvent<HTMLDivElement>, todo: PathTodo) => void;
   onTouchMove: (e: TouchEvent<HTMLDivElement>) => void;
   draggingTodo: DraggingTodo | null;
-  isDraggingTodo: boolean;
+  hasDraggingItem: boolean;
   itemRef?: LegacyRef<HTMLDivElement>;
 }
 
@@ -23,7 +23,7 @@ const TimeBlockItem = ({
   onTouchStart,
   onTouchMove,
   draggingTodo,
-  isDraggingTodo,
+  hasDraggingItem,
   itemRef,
 }: TimeBlockItemProps) => {
   const { todoId, category, title, memo, isDone } = todo;
@@ -31,13 +31,13 @@ const TimeBlockItem = ({
 
   const { handleCheckTodo, handleUncheckTodo, isAnimatingCheck } = useCheckTodo(
     todo,
-    isDraggingTodo,
+    hasDraggingItem,
   );
   const showTodoBottomSheet = useShowTodoBottomSheet();
 
   const handleViewTodo = () => {
-    if (isDraggingTodo) return;
-    alert(`dragging: ${draggingTodo?.todo.title}`);
+    if (hasDraggingItem) return;
+
     showTodoBottomSheet(todo);
   };
 
@@ -59,9 +59,6 @@ const TimeBlockItem = ({
         <Icon icon={ICON_MAPPER[category]} cursor="pointer" width={28} height={28} />
       </S.CheckIconWrapper>
       <S.TimeBlockContent onClick={handleViewTodo}>
-        <span>
-          {isDraggingTodo.toString()} {isDragging.toString()}
-        </span>
         <S.TodoTitle $isDone={isDone}>{title}</S.TodoTitle>
         <S.TodoMemo>{memo}</S.TodoMemo>
       </S.TimeBlockContent>

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/index.tsx
@@ -16,7 +16,7 @@ interface TimeBlockListProps {
 }
 
 const TimeBlockList = ({ todos, draggingTodo, onTouchStart, onTouchMove }: TimeBlockListProps) => {
-  const isDraggingTodo = todos.some((todo) => todo.todoId === draggingTodo?.todo.todoId);
+  const hasDraggingItem = todos.some((todo) => todo.todoId === draggingTodo?.todo.todoId);
 
   if (todos.length === 0) {
     return (
@@ -33,7 +33,7 @@ const TimeBlockList = ({ todos, draggingTodo, onTouchStart, onTouchMove }: TimeB
         <TimeBlockItem
           key={todo.todoId}
           todo={todo}
-          isDraggingTodo={isDraggingTodo}
+          hasDraggingItem={hasDraggingItem}
           onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
           draggingTodo={draggingTodo}

--- a/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/index.tsx
+++ b/frontend/src/pages/PlanPage/components/TimeBlockContent/TimeBlockList/index.tsx
@@ -16,6 +16,8 @@ interface TimeBlockListProps {
 }
 
 const TimeBlockList = ({ todos, draggingTodo, onTouchStart, onTouchMove }: TimeBlockListProps) => {
+  const isDraggingTodo = todos.some((todo) => todo.todoId === draggingTodo?.todo.todoId);
+
   if (todos.length === 0) {
     return (
       <S.EmptyTimeBlock>
@@ -31,6 +33,7 @@ const TimeBlockList = ({ todos, draggingTodo, onTouchStart, onTouchMove }: TimeB
         <TimeBlockItem
           key={todo.todoId}
           todo={todo}
+          isDraggingTodo={isDraggingTodo}
           onTouchStart={onTouchStart}
           onTouchMove={onTouchMove}
           draggingTodo={draggingTodo}

--- a/frontend/src/pages/PlanPage/hooks/useUpdatePathTodoMutation.ts
+++ b/frontend/src/pages/PlanPage/hooks/useUpdatePathTodoMutation.ts
@@ -28,7 +28,6 @@ const useUpdatePathTodoMutation = () => {
       });
 
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.favorite] });
-      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendLimit] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.recommendAll] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.routeTodoList] });
     },

--- a/frontend/src/pages/RecommendTodoPage/components/RecommendTodoContainer/index.tsx
+++ b/frontend/src/pages/RecommendTodoPage/components/RecommendTodoContainer/index.tsx
@@ -9,13 +9,11 @@ import { getTodoType } from '../../RecommendTodoPage.utils';
 import IconButton from '@/components/Button/IconButton';
 import Icon from '@/components/Icon';
 import IntersectionObserverScroll from '@/components/IntersectionObserverScroll/IntersectionObserverScroll';
-import { MAX_TODO_ITEM_LENGTH, TODO_TYPE } from '@/constants/config';
 import { TODO_TOAST_MESSAGE } from '@/constants/message';
 import useMemberInfoQuery from '@/hooks/useMemberInfoQuery';
 import useOverlay from '@/hooks/useOverlay';
 import useQueryParamsDate from '@/hooks/useQueryParamsDate';
 import useToast from '@/hooks/useToast';
-import useTodoListQuery from '@/hooks/useTodoListQuery';
 import TodoEditItem from '@/pages/EditPage/components/TodoEditItem';
 import useAddTodoFromArchivedMutation from '@/pages/EditPage/hooks/useAddTodoFromArchivedMutation';
 import { CategoryType, DifficultyType } from '@/types/filter';
@@ -34,13 +32,11 @@ const RecommendTodoContainer = ({ isFavoritePage }: RecommendTodoContainerProps)
   const [isInitialized, setIsInitialized] = useState(false);
 
   const { data: memberInfo } = useMemberInfoQuery();
-  const { data: todoList } = useTodoListQuery(dateType, Number(planId));
 
   const todoType = getTodoType({ dateType, isFavoritePage, planId });
 
   const {
     data: recommendList,
-    isLoading,
     isFetching,
     hasNextPage,
     fetchNextPage,
@@ -62,14 +58,6 @@ const RecommendTodoContainer = ({ isFavoritePage }: RecommendTodoContainerProps)
   };
 
   const handleAddTodoFromRecommendAll = (todoId: number) => {
-    const isLimitType = todoType === TODO_TYPE.TODAY || todoType === TODO_TYPE.TOMORROW;
-
-    if (isLimitType && todoList && todoList.length >= MAX_TODO_ITEM_LENGTH) {
-      toast({ message: TODO_TOAST_MESSAGE.limit(todoType) });
-
-      return;
-    }
-
     addTodoFromArchived(
       { todoType, todoId, planId: Number(planId) },
       {
@@ -90,9 +78,6 @@ const RecommendTodoContainer = ({ isFavoritePage }: RecommendTodoContainerProps)
       setIsInitialized(true);
     }
   }, [isInitialized, memberInfo]);
-
-  // 로딩중
-  if (isLoading) return <div>로딩중...</div>;
 
   // 데이터가 없을 경우
   if (!recommendList) return <div>추천 할 일 데이터가 없습니다.</div>;


### PR DESCRIPTION
## Issue Number
close #247 

## As-Is
<!-- 문제 상황 정의 -->
- 이동중일 때 즐겨찾기 목록에서 오늘 할 일을 못불러옴
- 드래그 앤 드롭에 의한 터치 이벤트가 막혀있지 않음
- 추천 할 일을 추가할 때마다 새로고침되는 문제

## To-Be
<!-- 변경 사항 -->
- [x] 드래그 앤 드롭에 의한 클릭 이벤트 방지
- [x] 이동중 즐겨찾기 목록에서 오늘 할 일을 불러오지 못해 에러 발생하는 문제 해결
- [x] 추천 할 일을 추가할 때마다 데이터를 다시 불러오는 문제 해결

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description

## 드래그 앤 드롭에 의한 터치 이벤트 방지

  - 드래그된 요소에만 e.preventDefault()가 호출되고, 다른 요소에서는 동작
  - 하나의 리스트 내에서만 레이아웃이 변경되므로, 아이템 각각이 아닌 리스트 내에서 dragging 중인지 체크함
  - 드래그 놓은 위치가 리스트 외부일 경우에 드래그 요소에 클릭 이벤트가 발생하는데, 글로벌 이벤트 리스너 등록으로 해결
  - 이벤트 핸들러가 이중으로 호출되는 문제를 stopPropagation을 통해 버블링을 통한 이벤트 전파 방지

## 이동중 즐겨찾기 목록에서 오늘 할 일을 불러오지 못해 에러 발생하는 문제 해결

- 오늘 할 일을 불러오는 이유는 수정하기 탭에서 오늘 할 일 개수를 체크하기 위해 불러왔고, 즐겨찾기 페이지에서는 필요없지만 컴포넌트를 공용으로 사용해서 해당 문제가 발생
- planId를 즐겨찾기 페이지에 넘겨주는 방식도 존재, 하지만 navigate 방식이 번거로워 에러 처리로 해결

## 추천 할 일을 추가할 때마다 데이터를 다시 불러오는 문제 해결

  - 추천 할 일이 랜덤으로 불러와지고, 같은 API에 대해 invalidate할 때와 안해야할 때를 쿼리키로 구분하기 어려움이 있다는 점에서 `gcTime:0` 으로 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved touch and drag interactions on the planning page for a smoother, more reliable experience.
  - Streamlined the handling of drag states for task items, resulting in enhanced responsiveness during drag-and-drop actions.
  - Introduced a new property to track dragging state for todo items, simplifying the component logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->