### PR TITLE
[FIX] ErrorBoundary 수정 및 토큰이 없는 경우 에러 추가

### DIFF
--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -50,6 +50,7 @@ export const ERROR_MESSAGE: Record<ErrorCode | clientErrorType, string> = {
   TOKEN_BLACKLISTED: '차단된 인증 정보입니다. 관리자에게 문의해주세요.',
   MISSING_TOKEN_IN_COOKIE: '인증 정보가 없어요. 다시 로그인해 주세요.',
   REFRESH_TOKEN_EXPIRED: '로그인 세션이 만료되었어요. 다시 로그인해 주세요.',
+  TOKEN_MISSING: '인증 정보가 없어요. 다시 로그인해 주세요.',
 
   NAVER_SERVICE_UNAVAILABLE: '네이버 서비스가 현재 이용 불가능합니다. 잠시 후 다시 시도해 주세요.',
 

--- a/frontend/src/pages/ErrorPage/ErrorPage.styled.ts
+++ b/frontend/src/pages/ErrorPage/ErrorPage.styled.ts
@@ -27,6 +27,11 @@ export const ErrorSubTitle = styled.h2`
   max-width: 36rem;
   text-align: center;
 `;
+export const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+`;
 
 export const ErrorButton = styled.button`
   ${({ theme }) => theme.fonts.body16};

--- a/frontend/src/pages/ErrorPage/index.tsx
+++ b/frontend/src/pages/ErrorPage/index.tsx
@@ -25,7 +25,10 @@ const ErrorPage = ({ message, onClick }: ErrorPageProps) => {
           </>
         )}
       </S.TitleContainer>
-      <S.ErrorButton onClick={onClick || goToHome}>다시 시도</S.ErrorButton>
+      <S.ButtonContainer>
+        <S.ErrorButton onClick={onClick}>다시 시도</S.ErrorButton>
+        <S.ErrorButton onClick={goToHome}>홈으로</S.ErrorButton>
+      </S.ButtonContainer>
     </S.ErrorLayout>
   );
 };

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -115,7 +115,6 @@ export const router = createBrowserRouter([
                 ),
               },
             ],
-            loader: memberStatusLoader,
             errorElement: <ErrorPage />,
           },
         ],

--- a/frontend/src/router/memberStatusLoader.ts
+++ b/frontend/src/router/memberStatusLoader.ts
@@ -45,7 +45,8 @@ const memberStatusLoader = async ({ request }: { request: Request }) => {
       error.errorCode === 'TOKEN_INVALID' ||
       error.errorCode === 'TOKEN_BLACKLISTED' ||
       error.errorCode === 'MISSING_TOKEN_IN_COOKIE' ||
-      error.errorCode === 'REFRESH_TOKEN_EXPIRED';
+      error.errorCode === 'REFRESH_TOKEN_EXPIRED' ||
+      error.errorCode === 'TOKEN_MISSING';
 
     if (isExpired) {
       return redirect('/landing');

--- a/frontend/src/types/error.ts
+++ b/frontend/src/types/error.ts
@@ -25,7 +25,8 @@ export type ErrorCode =
   | 'TOKEN_BLACKLISTED'
   | 'MISSING_TOKEN_IN_COOKIE'
   | 'REFRESH_TOKEN_EXPIRED'
-  | 'NAVER_SERVICE_UNAVAILABLE';
+  | 'NAVER_SERVICE_UNAVAILABLE'
+  | 'TOKEN_MISSING';
 
 export interface ResponseError {
   errorCode: ErrorCode;


### PR DESCRIPTION
## Issue Number
close #255 

## As-Is
<!-- 문제 상황 정의 -->
- 다시 시도 실패 시 페이지에 갇힘
- TOKEN_MISSING 에러 시 처리가 안됨
- 경로별 할 일이 안들어가짐

## To-Be
<!-- 변경 사항 -->
- [x] ErrorBoundary에서 로그인 페이지로 이동하는 버튼 추가
- [x] 토큰이 없는 경우 에러 추가
- [x] 경로별 할 일 loader 설정 제거

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling now displays a clear message when authentication information is missing.
  - The error page has been redesigned with two distinct buttons—one for retrying the action and another for returning to the home page.
- **Refactor**
  - Streamlined navigation by removing redundant data loading, contributing to improved overall performance and stability.
  - Updated the button layout for a more intuitive and polished user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->