### PR TITLE
[FIX] 에러 페이지 버튼 텍스트 깨지는 문제 해결

### DIFF
--- a/frontend/src/pages/ErrorPage/ErrorPage.styled.ts
+++ b/frontend/src/pages/ErrorPage/ErrorPage.styled.ts
@@ -43,6 +43,4 @@ export const ErrorButton = styled.button`
   padding: 1.5rem 3rem;
   gap: 0.4rem;
   border-radius: 3.2rem;
-
-  width: 40%;
 `;


### PR DESCRIPTION
## Issue Number
close #258 

## As-Is

<!-- 문제 상황 정의 -->
- 에러 페이지의 버튼 텍스트가 깨짐

## To-Be
<!-- 변경 사항 -->
- 에러 페이지의 버튼 텍스트 너비 수정

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

|before|after|
|:-:|:-:|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/d7401b06-bee5-4f41-83bf-87f68ae433d8" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/e1c0a94a-e91e-4012-afa8-4a0058ffe153" />|


## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the error page button’s appearance by removing a fixed width, which alters its layout on the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->