### PR TITLE
[FEAT] 로그아웃 및 회원 탈퇴 기능 구현

### DIFF
--- a/backend/src/main/java/com/dubu/backend/core/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/dubu/backend/core/exception/GlobalExceptionHandler.java
@@ -56,14 +56,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleMissingRequestCookieException(MissingRequestCookieException e) {
-        log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.NOT_FOUND_COOKIE);
-    }
-
-    @ExceptionHandler
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         log.warn(e.getMessage());
 

--- a/backend/src/main/java/com/dubu/backend/core/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/dubu/backend/core/exception/GlobalExceptionHandler.java
@@ -87,6 +87,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse handleMissingCookie(MissingRequestCookieException ex) {
+        log.warn("Missing Cookie : {}", ex.getCookieName());
+
+        return new ErrorResponse(ErrorCode.MISSING_TOKEN_IN_COOKIE);
+    }
+
+    @ExceptionHandler
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNotFoundException(NotFoundException e){
         log.warn(e.getMessage());

--- a/backend/src/main/java/com/dubu/backend/core/interceptor/TokenInterceptor.java
+++ b/backend/src/main/java/com/dubu/backend/core/interceptor/TokenInterceptor.java
@@ -43,7 +43,7 @@ public class TokenInterceptor implements HandlerInterceptor {
         }
 
         if (jwtToken.startsWith(BEARER_PREFIX)) {
-            return jwtToken.substring(7);
+            return jwtToken.substring(BEARER_PREFIX.length());
         } else {
             throw new InvalidTokenHeaderException();
         }

--- a/backend/src/main/java/com/dubu/backend/core/interceptor/TokenInterceptor.java
+++ b/backend/src/main/java/com/dubu/backend/core/interceptor/TokenInterceptor.java
@@ -2,7 +2,8 @@ package com.dubu.backend.core.interceptor;
 
 import com.dubu.backend.core.interceptor.context.TokenContext;
 import com.dubu.backend.member.application.TokenFacade;
-import com.dubu.backend.member.domain.repository.MemberRepository;
+import com.dubu.backend.member.core.exception.InvalidTokenHeaderException;
+import com.dubu.backend.member.core.exception.TokenMissingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +15,15 @@ import org.springframework.web.servlet.ModelAndView;
 @Component
 @RequiredArgsConstructor
 public class TokenInterceptor implements HandlerInterceptor {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private final TokenFacade tokenFacade;
-    private final MemberRepository memberRepository;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         if (handler instanceof HandlerMethod handlerMethod) {
-            String token = tokenFacade.resolveToken(request);
+            String token = resolveToken(request);
             Long memberId = tokenFacade.validateToken(token);
             TokenContext.setToken(token);
             request.setAttribute("memberId", memberId);
@@ -32,5 +34,18 @@ public class TokenInterceptor implements HandlerInterceptor {
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
         TokenContext.clear();
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String jwtToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (jwtToken == null) {
+            throw new TokenMissingException();
+        }
+
+        if (jwtToken.startsWith(BEARER_PREFIX)) {
+            return jwtToken.substring(7);
+        } else {
+            throw new InvalidTokenHeaderException();
+        }
     }
 }

--- a/backend/src/main/java/com/dubu/backend/core/util/DateTimeUtils.java
+++ b/backend/src/main/java/com/dubu/backend/core/util/DateTimeUtils.java
@@ -1,0 +1,30 @@
+package com.dubu.backend.core.util;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.*;
+
+@UtilityClass
+public class DateTimeUtils {
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+
+    public static LocalDateTime toSeoulDateTime(Instant instant) {
+        return instant.atZone(DEFAULT_ZONE).toLocalDateTime();
+    }
+
+    public static Instant toInstant(LocalDateTime localDateTime) {
+        return localDateTime.atZone(DEFAULT_ZONE).toInstant();
+    }
+
+    public static LocalDateTime nowSeoulDateTime() {
+        return LocalDateTime.now(DEFAULT_ZONE);
+    }
+
+    public static LocalDate nowSeoulDate() {
+        return LocalDate.now(DEFAULT_ZONE);
+    }
+
+    public static Instant nowSeoulInstant() {
+        return ZonedDateTime.now(DEFAULT_ZONE).toInstant();
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/member/api/AddressController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/AddressController.java
@@ -1,6 +1,7 @@
 package com.dubu.backend.member.api;
 
 import com.dubu.backend.core.domain.SuccessResponse;
+import com.dubu.backend.member.api.swagger.AddressSwagger;
 import com.dubu.backend.member.application.AddressFacade;
 import com.dubu.backend.member.api.response.AddressSearchResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/places")
-public class AddressController implements AddressApi {
+public class AddressController implements AddressSwagger {
     private final AddressFacade addressFacade;
 
     @GetMapping("/search")

--- a/backend/src/main/java/com/dubu/backend/member/api/AuthController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/AuthController.java
@@ -1,5 +1,6 @@
 package com.dubu.backend.member.api;
 
+import com.dubu.backend.member.api.swagger.AuthSwagger;
 import com.dubu.backend.member.application.AuthFacade;
 import com.dubu.backend.member.core.JwtProperties;
 import com.dubu.backend.member.api.response.AccessToken;
@@ -22,7 +23,7 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
-public class AuthController implements AuthApi {
+public class AuthController implements AuthSwagger {
     public static final long HOURS_IN_MINIUTES = 60 * 60L;
 
     private final JwtProperties jwtProperties;

--- a/backend/src/main/java/com/dubu/backend/member/api/AuthController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/AuthController.java
@@ -1,21 +1,19 @@
 package com.dubu.backend.member.api;
 
-import com.dubu.backend.member.api.swagger.AuthSwagger;
-import com.dubu.backend.member.application.AuthFacade;
-import com.dubu.backend.member.core.JwtProperties;
+import com.dubu.backend.core.domain.SuccessResponse;
 import com.dubu.backend.member.api.response.AccessToken;
 import com.dubu.backend.member.api.response.Token;
-import com.dubu.backend.member.core.exception.MissingTokenInCookieException;
-import com.dubu.backend.core.domain.SuccessResponse;
+import com.dubu.backend.member.api.swagger.AuthSwagger;
+import com.dubu.backend.member.application.AuthFacade;
+import com.dubu.backend.member.application.TokenFacade;
+import com.dubu.backend.member.core.JwtProperties;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -28,9 +26,10 @@ public class AuthController implements AuthSwagger {
 
     private final JwtProperties jwtProperties;
     private final AuthFacade authFacade;
+    private final TokenFacade tokenFacade;
 
     @PostMapping("/kakao-login")
-    public SuccessResponse<AccessToken> kakaoCallback(
+    public SuccessResponse<AccessToken> kakaoLogin(
             @RequestBody Map<String, String> request,
             HttpServletResponse response
     ) {
@@ -43,15 +42,9 @@ public class AuthController implements AuthSwagger {
 
     @PostMapping("/reissue")
     public SuccessResponse<AccessToken> reissue(
-            HttpServletRequest request,
+            @CookieValue(value = "REFRESH_TOKEN", required = false) String refreshToken,
             HttpServletResponse response
     ) {
-        String refreshToken = extractRefreshToken(request);
-
-        if (refreshToken == null) {
-            throw new MissingTokenInCookieException();
-        }
-
         Token token = authFacade.reissueToken(refreshToken);
         sendCookie(response, token.refreshToken());
 

--- a/backend/src/main/java/com/dubu/backend/member/api/AuthController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/AuthController.java
@@ -51,6 +51,22 @@ public class AuthController implements AuthSwagger {
         return new SuccessResponse<>(new AccessToken(token.accessToken()));
     }
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/logout")
+    public void logout(
+            @CookieValue(value = "REFRESH_TOKEN", required = false) String refreshToken
+    ) {
+        tokenFacade.logout(refreshToken);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/account")
+    public void deleteAccount(
+            @RequestAttribute("memberId") Long memberId
+    ) {
+        authFacade.deleteAccount(memberId);
+    }
+
     @PostMapping("/test/token")
     public SuccessResponse<AccessToken> testToken() {
         AccessToken response = authFacade.issueTokenForTest();

--- a/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/MemberController.java
@@ -8,6 +8,7 @@ import com.dubu.backend.member.api.response.MemberInfoResponse;
 import com.dubu.backend.member.api.response.MemberResponse;
 import com.dubu.backend.member.api.response.MemberSavedAddressResponse;
 import com.dubu.backend.member.api.response.MemberStatusResponse;
+import com.dubu.backend.member.api.swagger.MemberSwagger;
 import com.dubu.backend.member.application.MemberCommandFacade;
 import com.dubu.backend.member.application.MemberLocationFacade;
 import com.dubu.backend.member.application.MemberQueryFacade;
@@ -28,7 +29,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
-public class MemberController implements MemberApi {
+public class MemberController implements MemberSwagger {
     private final MemberQueryFacade memberQueryFacade;
     private final MemberCommandFacade memberCommandFacade;
     private final MemberLocationFacade memberLocationFacade;

--- a/backend/src/main/java/com/dubu/backend/member/api/swagger/AddressSwagger.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/swagger/AddressSwagger.java
@@ -1,4 +1,4 @@
-package com.dubu.backend.member.api;
+package com.dubu.backend.member.api.swagger;
 
 import com.dubu.backend.core.domain.SuccessResponse;
 import com.dubu.backend.member.api.response.AddressSearchResponse;
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-public interface AddressApi {
+public interface AddressSwagger {
     @Operation(
             summary = "장소 검색",
             description = """

--- a/backend/src/main/java/com/dubu/backend/member/api/swagger/AuthSwagger.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/swagger/AuthSwagger.java
@@ -1,17 +1,22 @@
 package com.dubu.backend.member.api.swagger;
 
+import com.dubu.backend.core.domain.ErrorResponse;
+import com.dubu.backend.core.domain.SuccessResponse;
 import com.dubu.backend.member.api.response.AccessToken;
 import com.dubu.backend.member.api.response.Token;
-import com.dubu.backend.core.domain.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.Map;
 
@@ -59,7 +64,7 @@ public interface AuthSwagger {
                     )
             )
     })
-    SuccessResponse<AccessToken> kakaoCallback(
+    SuccessResponse<AccessToken> kakaoLogin(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "카카오에서 인가 코드를 전달받을 때 사용되는 필드(code)",
                     required = true,
@@ -144,10 +149,58 @@ public interface AuthSwagger {
             )
     })
     SuccessResponse<AccessToken> reissue(
-            HttpServletRequest request,
+            String refreshToken,
             HttpServletResponse response
     );
 
+    /*──────────────────────────────────────────────────────
+     * 로그아웃
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "로그아웃",
+            description = """
+            쿠키에 위치한 Refresh Token을 블랙리스트 처리해 재사용을 차단합니다.<br>
+            클라이언트 측에서 기존에 관리하던 AccessToken을 제거해야합니다
+            """,
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "로그아웃 완료")
+            }
+    )
+    @PostMapping("/logout")
+    void logout(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String token
+    );
+
+    /*──────────────────────────────────────────────────────
+     * 회원 탈퇴
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "회원 탈퇴",
+            description = """
+            존재하는 회원인지 여부를 확인한 후 회원의 계정을 삭제합니다.
+            """,
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "탈퇴 완료"),
+                    @ApiResponse(responseCode = "404",
+                            description = "NOT_FOUND_MEMBER",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                        {
+                          "errorCode": "NOT_FOUND_MEMBER",
+                          "message": "회원을 찾을 수 없습니다. MemberId : 42"
+                        }"""
+                                    )))
+            }
+    )
+    @DeleteMapping("/account")
+    void deleteAccount(
+            @RequestAttribute("memberId") Long memberId
+    );
+
+    /*──────────────────────────────────────────────────────
+     * 테스트용 토큰 발급
+     *──────────────────────────────────────────────────────*/
     @Operation(
             summary = "테스트용 토큰 발급",
             description = "회원 1번(고정)에 대한 임시 액세스 토큰을 발급한다."

--- a/backend/src/main/java/com/dubu/backend/member/api/swagger/AuthSwagger.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/swagger/AuthSwagger.java
@@ -1,4 +1,4 @@
-package com.dubu.backend.member.api;
+package com.dubu.backend.member.api.swagger;
 
 import com.dubu.backend.member.api.response.AccessToken;
 import com.dubu.backend.member.api.response.Token;
@@ -15,7 +15,7 @@ import org.springframework.http.MediaType;
 
 import java.util.Map;
 
-public interface AuthApi {
+public interface AuthSwagger {
     @Operation(
             summary = "카카오 로그인 콜백 처리",
             description = """

--- a/backend/src/main/java/com/dubu/backend/member/api/swagger/MemberSwagger.java
+++ b/backend/src/main/java/com/dubu/backend/member/api/swagger/MemberSwagger.java
@@ -1,4 +1,4 @@
-package com.dubu.backend.member.api;
+package com.dubu.backend.member.api.swagger;
 
 import com.dubu.backend.core.domain.SuccessResponse;
 import com.dubu.backend.member.domain.model.MemberLocation;
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
-public interface MemberApi {
+public interface MemberSwagger {
 
     @Operation(
             summary = "회원 정보 조회",

--- a/backend/src/main/java/com/dubu/backend/member/application/AuthFacade.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/AuthFacade.java
@@ -37,6 +37,12 @@ public class AuthFacade {
         return token;
     }
 
+    @Transactional
+    public void deleteAccount(Long memberId) {
+        Member member = memberService.findExistingMember(memberId);
+        member.deactivate();
+    }
+
     public AccessToken issueTokenForTest() {
         Token token = tokenFacade.issue(1L);
 

--- a/backend/src/main/java/com/dubu/backend/member/application/AuthFacade.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/AuthFacade.java
@@ -1,12 +1,11 @@
 package com.dubu.backend.member.application;
 
-import com.dubu.backend.member.application.api.OauthApi;
-import com.dubu.backend.member.domain.enums.OauthProvider;
 import com.dubu.backend.member.api.response.AccessToken;
-import com.dubu.backend.member.api.response.UserInfo;
 import com.dubu.backend.member.api.response.Token;
+import com.dubu.backend.member.api.response.UserInfo;
+import com.dubu.backend.member.application.api.OauthApi;
 import com.dubu.backend.member.domain.model.Member;
-import com.dubu.backend.member.domain.repository.MemberRepository;
+import com.dubu.backend.member.domain.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,23 +17,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthFacade {
     private final OauthApi oauthApi;
     private final TokenFacade tokenFacade;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Transactional
     public Token kakaoLogin(String code) {
         String accessToken = oauthApi.getAccessToken(code);
         UserInfo userInfo = oauthApi.getOauthUser(accessToken);
 
-        Member member = memberRepository.findByOauthProviderId(userInfo.oauthProviderId())
-                .orElseGet(() -> creatMember(userInfo));
+        Member member = memberService.findOrCreateMember(userInfo);
 
         return tokenFacade.issue(member.getId());
     }
 
     public Token reissueToken(String oldRefreshToken) {
-        Token token = tokenFacade.reissue(oldRefreshToken);
-
-        return token;
+        return tokenFacade.reissue(oldRefreshToken);
     }
 
     @Transactional
@@ -47,14 +43,5 @@ public class AuthFacade {
         Token token = tokenFacade.issue(1L);
 
         return new AccessToken(token.accessToken());
-    }
-
-    private Member creatMember(UserInfo userInfo) {
-        Member newMember = Member.of(
-                userInfo.email(),
-                OauthProvider.KAKAO,
-                userInfo.oauthProviderId()
-        );
-        return memberRepository.save(newMember);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/member/application/TokenFacade.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/TokenFacade.java
@@ -1,28 +1,27 @@
 package com.dubu.backend.member.application;
 
 import com.dubu.backend.member.api.response.Token;
-import com.dubu.backend.member.infrastructure.RedisTokenRepository;
+import com.dubu.backend.member.application.dto.TokenInfo;
 import com.dubu.backend.member.core.JwtProperties;
-import com.dubu.backend.member.core.exception.InvalidTokenHeaderException;
+import com.dubu.backend.member.core.exception.RefreshTokenExpiredException;
 import com.dubu.backend.member.core.exception.TokenBlacklistedException;
-import com.dubu.backend.member.core.exception.TokenMissingException;
-import io.jsonwebtoken.Claims;
+import com.dubu.backend.member.infrastructure.RedisTokenRepository;
 import jakarta.annotation.PostConstruct;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Date;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenFacade {
     public static final long HOURS_IN_MILLIS = 60 * 60 * 1000L;
 
     private final JwtProperties jwtProperties;
-    private final JwtManager jwtManager;
+    private final TokenManager tokenManager;
     private final RedisTokenRepository redisTokenRepository;
     private long accessTokenTime;
     private long refreshTokenTime;
@@ -34,8 +33,8 @@ public class TokenFacade {
     }
 
     public Token issue(Long memberId) {
-        String newAccessToken = jwtManager.createToken(memberId, accessTokenTime);
-        String newRefreshToken = jwtManager.createToken(memberId, refreshTokenTime);
+        String newAccessToken = tokenManager.createToken(memberId, accessTokenTime);
+        String newRefreshToken = tokenManager.createToken(memberId, refreshTokenTime);
 
         redisTokenRepository.saveRefreshToken(memberId.toString(), newRefreshToken, refreshTokenTime);
 
@@ -43,24 +42,17 @@ public class TokenFacade {
     }
 
     public Token reissue(String oldRefreshToken) {
-        Claims claims = jwtManager.parseClaimsFromRefreshToken(oldRefreshToken);
-
-        String jti = claims.getId();
-        String memberId = claims.getSubject();
+        TokenInfo tokenInfo = tokenManager.parseClaimsFromRefreshToken(oldRefreshToken);
+        String jti = tokenInfo.tokenId();
+        String memberId = tokenInfo.memberId();
 
         if (redisTokenRepository.isBlacklisted(jti)) {
-            String currentRefreshToken = redisTokenRepository.getRefreshToken(memberId);
-            Date expiration = jwtManager.parseClaimsFromRefreshToken(currentRefreshToken).getExpiration();
-            redisTokenRepository.addBlacklistToken(currentRefreshToken, getRemainingDuration(expiration));
-
             throw new TokenBlacklistedException();
         }
 
-        redisTokenRepository.addBlacklistToken(jti, getRemainingDuration(claims.getExpiration()));
+        redisTokenRepository.addBlacklistToken(jti, getRemainingDuration(tokenInfo.expiration()));
 
-        Token token = issue(Long.valueOf(memberId));
-
-        return token;
+        return issue(Long.valueOf(memberId));
     }
 
     public void logout(String refreshToken) {
@@ -76,29 +68,18 @@ public class TokenFacade {
     }
 
     public Long validateToken(String accessToken) {
-        Claims claims = jwtManager.parseClaims(accessToken);
-        String memberId = claims.getSubject();
+        TokenInfo tokenInfo = tokenManager.parseClaims(accessToken);
+        String memberId = tokenInfo.memberId();
 
         return Long.parseLong(memberId);
     }
 
-    public String resolveToken(HttpServletRequest request) {
-        String jwtToken = request.getHeader("Authorization");
-        if (jwtToken == null) {
-            throw new TokenMissingException();
-        }
-
-        if (jwtToken.startsWith("Bearer ")) {
-            return jwtToken.substring(7);
-        } else {
-            throw new InvalidTokenHeaderException();
-        }
-    }
-
-    private Duration getRemainingDuration(Date expiration) {
+    private Duration getRemainingDuration(Instant expiration) {
         Instant now = Instant.now();
-        Instant expirationTime = expiration.toInstant();
+        if(now.isAfter(expiration)) {
+            throw new RefreshTokenExpiredException();
+        }
 
-        return Duration.between(now, expirationTime);
+        return Duration.between(now, expiration);
     }
 }

--- a/backend/src/main/java/com/dubu/backend/member/application/TokenFacade.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/TokenFacade.java
@@ -63,6 +63,18 @@ public class TokenFacade {
         return token;
     }
 
+    public void logout(String refreshToken) {
+        try {
+            TokenInfo tokenInfo = tokenManager.parseClaimsFromRefreshToken(refreshToken);
+            String jti = tokenInfo.tokenId();
+            Instant expiration = tokenInfo.expiration();
+
+            redisTokenRepository.addBlacklistToken(jti, getRemainingDuration(expiration));
+        } catch (Exception e) {
+            log.warn("Invalid refresh token during logout. Token: {}", refreshToken, e);
+        }
+    }
+
     public Long validateToken(String accessToken) {
         Claims claims = jwtManager.parseClaims(accessToken);
         String memberId = claims.getSubject();

--- a/backend/src/main/java/com/dubu/backend/member/application/TokenManager.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/TokenManager.java
@@ -1,5 +1,6 @@
 package com.dubu.backend.member.application;
 
+import com.dubu.backend.member.application.dto.TokenInfo;
 import com.dubu.backend.member.core.exception.RefreshTokenExpiredException;
 import com.dubu.backend.member.core.exception.TokenExpiredException;
 import com.dubu.backend.member.core.exception.TokenInvalidException;
@@ -18,8 +19,7 @@ import java.util.Date;
 import java.util.UUID;
 
 @Component
-public class JwtManager {
-
+public class TokenManager {
     public static final String TOKEN_ISSUER = "DUBU";
 
     @Value("${jwt.secret}")
@@ -47,14 +47,15 @@ public class JwtManager {
                 .compact();
     }
 
-    public Claims parseClaims(String token) {
+    public TokenInfo parseClaims(String token) {
         try {
-            return Jwts.parser()
+            Claims claims = Jwts.parser()
                     .requireIssuer(TOKEN_ISSUER)
                     .verifyWith(secretKey)
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
+            return new TokenInfo(claims.getId(), claims.getSubject(), claims.getExpiration().toInstant());
         } catch (ExpiredJwtException ex) {
             throw new TokenExpiredException();
         } catch (JwtException ex) {
@@ -62,14 +63,15 @@ public class JwtManager {
         }
     }
 
-    public Claims parseClaimsFromRefreshToken(String token) {
+    public TokenInfo parseClaimsFromRefreshToken(String token) {
         try {
-            return Jwts.parser()
+            Claims claims = Jwts.parser()
                     .requireIssuer(TOKEN_ISSUER)
                     .verifyWith(secretKey)
                     .build()
                     .parseSignedClaims(token)
                     .getPayload();
+            return new TokenInfo(claims.getId(), claims.getSubject(), claims.getExpiration().toInstant());
         } catch (ExpiredJwtException ex) {
             throw new RefreshTokenExpiredException();
         } catch (JwtException ex) {

--- a/backend/src/main/java/com/dubu/backend/member/application/dto/TokenInfo.java
+++ b/backend/src/main/java/com/dubu/backend/member/application/dto/TokenInfo.java
@@ -1,0 +1,10 @@
+package com.dubu.backend.member.application.dto;
+
+import java.time.Instant;
+
+public record TokenInfo(
+        String tokenId,
+        String memberId,
+        Instant expiration
+) {
+}

--- a/backend/src/main/java/com/dubu/backend/member/domain/model/Member.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/model/Member.java
@@ -1,12 +1,15 @@
 package com.dubu.backend.member.domain.model;
 
 import com.dubu.backend.core.domain.BaseTimeEntity;
+import com.dubu.backend.core.util.DateTimeUtils;
 import com.dubu.backend.member.core.AggregateRoot;
 import com.dubu.backend.member.domain.enums.MemberStatus;
 import com.dubu.backend.member.domain.enums.OauthProvider;
 import com.dubu.backend.member.domain.enums.Role;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.time.Instant;
 
 @AggregateRoot
 @Entity
@@ -26,12 +29,8 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private OauthProvider oauthProvider;
-
-    @Column(nullable = false)
-    private String oauthProviderId;
+    @Embedded
+    private OauthInfo oauthInfo;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -43,11 +42,13 @@ public class Member extends BaseTimeEntity {
 
     private String recentRoute;
 
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
     public static Member of(String email, OauthProvider oauthProvider, String oauthProviderId) {
         return Member.builder()
                 .email(email)
-                .oauthProvider(oauthProvider)
-                .oauthProviderId(oauthProviderId)
+                .oauthInfo(OauthInfo.of(oauthProvider, oauthProviderId))
                 .role(Role.USER)
                 .status(MemberStatus.ONBOARDING)
                 .build();

--- a/backend/src/main/java/com/dubu/backend/member/domain/model/Member.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/model/Member.java
@@ -64,4 +64,10 @@ public class Member extends BaseTimeEntity {
     public boolean isOnboarding() {
         return this.status == MemberStatus.ONBOARDING;
     }
+
+    public void deactivate() {
+        this.email = "deactivated-" + this.id;
+        this.oauthInfo = OauthInfo.of(this.getOauthInfo().getOauthProvider(), "0");
+        this.deletedAt = DateTimeUtils.nowSeoulInstant();
+    }
 }

--- a/backend/src/main/java/com/dubu/backend/member/domain/model/OauthInfo.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/model/OauthInfo.java
@@ -1,0 +1,28 @@
+package com.dubu.backend.member.domain.model;
+
+import com.dubu.backend.member.domain.enums.OauthProvider;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OauthInfo {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "oauth_provider", nullable = false)
+    private OauthProvider oauthProvider;
+
+    @Column(name = "oauth_provider_id", nullable = false)
+    private String oauthProviderId;
+
+    public static OauthInfo of(OauthProvider oauthProvider, String oauthProviderId) {
+        return new OauthInfo(oauthProvider, oauthProviderId);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/member/domain/repository/MemberRepository.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/repository/MemberRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByOauthProviderId(String providerId);
+    Optional<Member> findByEmail(String email);
 
     @Query("SELECT m FROM Member m WHERE m.id IN :memberIds")
     List<Member> findMembersByMemberIds(List<Long> memberIds);

--- a/backend/src/main/java/com/dubu/backend/member/domain/service/MemberService.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/service/MemberService.java
@@ -20,10 +20,10 @@ public class MemberService {
 
     public Member findOrCreateMember(UserInfo userInfo) {
         return memberRepository.findByEmail(userInfo.email())
-                .orElseGet(() -> creatMember(userInfo));
+                .orElseGet(() -> createMember(userInfo));
     }
 
-    private Member creatMember(UserInfo userInfo) {
+    private Member createMember(UserInfo userInfo) {
         Member newMember = Member.of(
                 userInfo.email(),
                 OauthProvider.KAKAO,

--- a/backend/src/main/java/com/dubu/backend/member/domain/service/MemberService.java
+++ b/backend/src/main/java/com/dubu/backend/member/domain/service/MemberService.java
@@ -1,0 +1,34 @@
+package com.dubu.backend.member.domain.service;
+
+import com.dubu.backend.member.api.response.UserInfo;
+import com.dubu.backend.member.core.exception.MemberNotFoundException;
+import com.dubu.backend.member.domain.enums.OauthProvider;
+import com.dubu.backend.member.domain.model.Member;
+import com.dubu.backend.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Member findExistingMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+    }
+
+    public Member findOrCreateMember(UserInfo userInfo) {
+        return memberRepository.findByEmail(userInfo.email())
+                .orElseGet(() -> creatMember(userInfo));
+    }
+
+    private Member creatMember(UserInfo userInfo) {
+        Member newMember = Member.of(
+                userInfo.email(),
+                OauthProvider.KAKAO,
+                userInfo.oauthProviderId()
+        );
+        return memberRepository.save(newMember);
+    }
+}

--- a/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
+++ b/backend/src/main/java/com/dubu/backend/plan/api/PlanApi.java
@@ -1,7 +1,7 @@
 package com.dubu.backend.plan.api;
 
 import com.dubu.backend.core.domain.SuccessResponse;
-import com.dubu.backend.member.api.MemberApi;
+import com.dubu.backend.member.api.swagger.MemberSwagger;
 import com.dubu.backend.plan.api.request.PlanCreateRequest;
 import com.dubu.backend.plan.api.request.PlanFeedbackCreateRequest;
 import com.dubu.backend.plan.api.response.FeedbackWritePageInfoResponse;
@@ -390,7 +390,7 @@ public interface PlanApi {
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(
-                                    implementation = MemberApi.ErrorResponseExample.class,
+                                    implementation = MemberSwagger.ErrorResponseExample.class,
                                     description = "에러 응답 예시"
                             ),
                             examples = {


### PR DESCRIPTION
## Issue Number
#283

## As-Is
<!-- 문제 상황 정의 -->
로그아웃 및 회원 탈퇴 기능을 구현 필요
인증 및 회원 처리 과정에서 리팩토링 필요

## To-Be
<!-- 변경 사항 -->
- [x] 로그아웃 기능 구현
- [x] 회원 탈퇴 기능 구현
- [x] Swagger 명세서 작성
- [x] 리팩토링
  - [x] Member 도메인 서비스로 비즈니스 로직 분리
  - [x] jwt라이브러리 분리를 위한 토큰 파싱 응답 TokenInfo를 사용하도록 변경

## Check List

- [x] 테스트가 전부 통과되었나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

## Test Screenshot

## (Optional) Additional Description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints for user logout and account deletion, allowing users to securely log out and delete their accounts.
  * Introduced utility methods for date and time handling in the Seoul time zone.
  * Implemented support for soft-deleting user accounts, tracking deletion time.

* **Improvements**
  * Enhanced token management with unified token handling and improved error responses for missing or invalid tokens.
  * Refined authentication and member management logic for better maintainability and security.
  * Updated API documentation and interface names for clearer Swagger/OpenAPI integration.

* **Bug Fixes**
  * Improved error handling for missing authentication cookies, now returning more appropriate error codes and messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->